### PR TITLE
fix: 修复更多选择时颜色设置未生效

### DIFF
--- a/packages/color-picker/src/index.vue
+++ b/packages/color-picker/src/index.vue
@@ -62,7 +62,7 @@ const bColor = ['#c21401', '#ff1e02', '#ffc12a', '#ffff3a', '#90cf5b', '#00af57'
 const html5Color = computed({
   get: () => props.modelValue,
   set: (value) => {
-    updataValue(value)
+    updateValue(value)
   }
 })
 // 计算属性：显示面板颜色
@@ -95,13 +95,13 @@ const triggerHtml5Color = () => {
   html5ColorEl.value?.click()
 }
 // 更新组件的值
-const updataValue = (value: string) => {
+const updateValue = (value: string) => {
   emits('update:modelValue', value)
   emits('change', value)
 }
 // 设置默认颜色
 const handleDefaultColor = () => {
-  updataValue(props.defaultColor)
+  updateValue(props.defaultColor)
 }
 
 /**
@@ -174,7 +174,7 @@ const gradient = (startColor: string, endColor: string, step: number) => {
             :style="{ backgroundColor: color }"
             @mouseover="handleOver(color)"
             @mouseout="handleOver('')"
-            @click="updataValue(color)"
+            @click="updateValue(color)"
           ></li>
         </ul>
         <ul class="bColor">
@@ -186,7 +186,7 @@ const gradient = (startColor: string, endColor: string, step: number) => {
                 :style="{ backgroundColor: color }"
                 @mouseover="handleOver(color)"
                 @mouseout="handleOver('')"
-                @click="updataValue(color)"
+                @click="updateValue(color)"
               ></li>
             </ul>
           </li>
@@ -199,7 +199,7 @@ const gradient = (startColor: string, endColor: string, step: number) => {
             :style="{ backgroundColor: color }"
             @mouseover="handleOver(color)"
             @mouseout="handleOver('')"
-            @click="updataValue(color)"
+            @click="updateValue(color)"
           ></li>
         </ul>
         <h3 @click="triggerHtml5Color">更多颜色...</h3>

--- a/packages/color-picker/src/index.vue
+++ b/packages/color-picker/src/index.vue
@@ -59,7 +59,12 @@ const colorConfig = [
   ]
 // 标准颜色
 const bColor = ['#c21401', '#ff1e02', '#ffc12a', '#ffff3a', '#90cf5b', '#00af57', '#00afee', '#0071be', '#00215f', '#72349d']
-const html5Color = props.modelValue
+const html5Color = computed({
+  get: () => props.modelValue,
+  set: (value) => {
+    updataValue(value)
+  }
+})
 // 计算属性：显示面板颜色
 const showPanelColor = computed(() => {
   if (hoveColor.value) {
@@ -93,7 +98,6 @@ const triggerHtml5Color = () => {
 const updataValue = (value: string) => {
   emits('update:modelValue', value)
   emits('change', value)
-  openStatus.value = false
 }
 // 设置默认颜色
 const handleDefaultColor = () => {
@@ -202,8 +206,7 @@ const gradient = (startColor: string, endColor: string, step: number) => {
         <!-- 用以激活HTML5颜色面板 -->
         <input type="color"
           ref="html5ColorEl"
-          v-model="html5Color"
-          @change="updataValue(html5Color)">
+          v-model="html5Color">
       </div>
     </div>
   </div>


### PR DESCRIPTION
关联bug: https://github.com/zuley/vue-color-picker/issues/22

注：此bug仅在打包后才会复现，开发模式正常。

修复前：

https://github.com/zuley/vue-color-picker/assets/16473062/6497895f-bcc7-434b-a5f4-3b96474d7886

修复后：

https://github.com/zuley/vue-color-picker/assets/16473062/9fed0832-01a6-42f1-958d-5f72fda3f7fa

