### PR TITLE
refactor(color-picker): a11y, perf, theming, and robustness pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vColorPicker
 
-> 基于Vue的颜色选择器插件
+> 基于 Vue 3 的颜色选择器插件
 [DEMO 演示](https://vue-color-picker.rxshc.com/)
 
 ## 安装
@@ -11,26 +11,32 @@ npm install vcolorpicker@1.1.0 -S
 # vue3
 npm install vcolorpicker -S
 ```
+
 ## 使用
+
 ### vue3 使用
-在`main.ts`文件中引入并注册
+
+在 `main.ts` 文件中引入并注册
+
 ```ts
 import vColorPicker from 'vcolorpicker'
 const app = createApp(App)
 app.use(vColorPicker)
 ```
+
 在页面中使用
+
 ```vue
 <script lang="ts" setup>
 import { ref } from 'vue'
 
 const color = ref('#ff0000')
-const headleChangeColor = (color: string) => {
+const handleChangeColor = (color: string) => {
   console.log(`颜色值改变事件：${color}`)
 }
 </script>
 <template>
-  <colorPicker v-model="color" @change="headleChangeColor"></colorPicker>
+  <colorPicker v-model="color" @change="handleChangeColor"></colorPicker>
 </template>
 ```
 
@@ -52,8 +58,8 @@ const color = ref('#3b82f6')
 </template>
 ```
 
-
 ### vue2 使用
+
 在 `main.js` 文件中引入插件并注册
 
 ``` bash
@@ -80,25 +86,128 @@ Vue.use(vcolorpicker)
 ```
 
 ## 特点
-1. 简单易用，UI在原插件基础上优化增加了圆角和过渡动画
+
+1. 简单易用，支持 `v-model`，UI 增加了圆角和过渡动画
 2. 提供以 `npm` 的形式安装提供全局组件
 3. 在支持 html5 input[type='color'] 的浏览器实现了「更多颜色」的功能
+4. **完整的键盘 / 屏幕阅读器可访问性**：`Tab` 聚焦、`Enter` / `Space` 激活、`Esc` 关闭，所有色块都带 `aria-label`
+5. **SSR 友好**：服务端渲染输出确定性 fallback，客户端挂载后再做语言检测，无 hydration mismatch
+6. **CSS Variables 主题化**：无需选择器穿透就能定制配色和尺寸
 
-## 选项
-你可以通过在所在的元素上设置以下属性来配置`color-picker`
-1. `defaultColor`：默认颜色，如`defaultColor="#ff0000"`
-2. `disabled`：禁用状态，如`disabled=true`
-3. `locale`：内置语言，可选值为`zh-CN`、`en-US`和`ja-JP`，不传时自动跟随当前页面语言
-4. `messages`：自定义文案对象，可覆盖`defaultColor`、`themeColors`、`standardColors`、`moreColors`
+## Props
+
+| 属性 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `v-model` / `modelValue` | `string` | — | 当前颜色值 |
+| `defaultColor` | `string` | `#000000` | 「默认颜色」按钮重置使用的颜色 |
+| `disabled` | `boolean` | `false` | 禁用状态 |
+| `locale` | `'zh-CN' \| 'en-US' \| 'ja-JP'` | 自动检测 | 面板内置文案语言；不传时跟随 `<html lang>` / `navigator.language` |
+| `messages` | `Partial<ColorPickerMessages>` | — | 自定义文案对象，覆盖 `defaultColor` / `themeColors` / `standardColors` / `moreColors` |
+| `placement` | `ColorPickerPlacement` | `'auto'` | 面板位置：`'auto'` / `'top'` / `'bottom'` / `'top-start'` / `'top-end'` / `'bottom-start'` / `'bottom-end'`。`'auto'` 根据视口剩余空间自动决定；带方向时锁定对应轴 |
 
 ## 事件
-`change`颜色值改变的时候触发
+
+| 事件名 | 参数 | 说明 |
+| --- | --- | --- |
+| `change` | `(color: string)` | 颜色值改变时触发 |
+| `update:modelValue` | `(color: string)` | `v-model` 同步事件 |
+| `open` | — | 面板打开时触发 |
+| `close` | — | 面板关闭时触发（点击外部 / Esc / 选色后自动关闭）|
+| `hover` | `(color: string)` | 鼠标移到色块时触发；离开时携带空字符串 |
 
 ``` js
-<colorPicker v-model="color" @change="headleChangeColor" />
+<colorPicker v-model="color" @change="handleChangeColor" />
+```
+
+## 命令式 API
+
+通过模板 ref 暴露的方法可命令式控制组件：
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { ColorPickerInstance } from 'vcolorpicker'
+
+const pickerRef = ref<ColorPickerInstance>()
+const color = ref('#ff0000')
+
+const openProgrammatically = () => pickerRef.value?.open()
+</script>
+
+<template>
+  <colorPicker ref="pickerRef" v-model="color" />
+  <button @click="openProgrammatically">打开面板</button>
+</template>
+```
+
+| 方法 | 说明 |
+| --- | --- |
+| `open()` | 打开面板（`disabled` 时无效）|
+| `close()` | 关闭面板 |
+| `focus()` | 把焦点移回触发按钮 |
+
+## 可访问性（a11y）
+
+- 触发按钮和所有色块都可通过 `Tab` 聚焦
+- `Enter` / `Space` 激活；触发按钮聚焦时按 `↑` / `↓` 也可打开面板
+- 面板打开后按 `Esc` 关闭并把焦点送回触发按钮
+- 触发按钮带 `role="button"` + `aria-haspopup="dialog"` + `aria-expanded`，面板带 `role="dialog"`，每个色块带 `aria-label="#RRGGBB"`
+- 焦点环使用 `:focus-visible`，鼠标用户不会被打扰
+
+## SSR / Nuxt
+
+- 在 Node 环境无 `document` / `navigator` 时，初始 locale 固定为 `zh-CN`（或显式 `locale` prop），保证服务端和客户端首屏一致
+- 组件 `onMounted` 后才执行真正的语言检测；如果要避免挂载后从中文跳变到其他语言的闪动，**建议在 SSR 场景显式传 `locale` prop**
+- `MutationObserver` 监听 `<html lang>` 变化时是模块级单例，多实例只占一份资源
+
+## CSS Variables 主题化
+
+无需穿透选择器，覆盖以下变量即可：
+
+```css
+.m-colorPicker {
+  --vcp-swatch-size: 15px;
+  --vcp-panel-width: 190px;
+  --vcp-panel-bg: #fff;
+  --vcp-panel-border: 1px solid #ddd;
+  --vcp-panel-radius: 2px;
+  --vcp-panel-shadow: 0 8px 24px rgba(0, 0, 0, .18);
+  --vcp-panel-padding: 10px;
+  --vcp-text-color: #333;
+  --vcp-focus-color: #4e81bb;
+  --vcp-transition: .3s ease;
+  --vcp-z-index: 10000;
+}
+```
+
+例：暗色主题
+
+```css
+.dark .m-colorPicker {
+  --vcp-panel-bg: #1f1f1f;
+  --vcp-panel-border: 1px solid #333;
+  --vcp-text-color: #eee;
+}
+```
+
+## TypeScript
+
+包内导出的类型：
+
+```ts
+import type {
+  ColorPickerProps,
+  ColorPickerEmits,
+  ColorPickerExposed,
+  ColorPickerInstance,
+  ColorPickerLocale,
+  ColorPickerMessages,
+  ColorPickerPlacement
+} from 'vcolorpicker'
 ```
 
 ## 赞助
+
 感谢赞助商支持：
 
 - <a href="https://aipromptcard.app" target="_blank" rel="noopener">AI Prompt Card：生成可分享的 AI Prompt 卡片</a>

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ layout: home
 hero:
   name: vColorPicker
   text: Vue 3 Color Picker
-  tagline: A lightweight, easy-to-use color picker component for Vue 3
+  tagline: A lightweight, accessible color picker component for Vue 3
   actions:
     - theme: brand
       text: Get Started
@@ -14,11 +14,13 @@ hero:
 
 features:
   - title: Easy to Use
-    details: Simple API with v-model support, optimized UI with rounded corners and smooth transitions
-  - title: npm Package
-    details: Install via npm and register as a global component, ready to use in any Vue 3 project
-  - title: HTML5 Color Picker
-    details: Supports "More Colors" via native HTML5 color input in compatible browsers
+    details: Simple v-model API with rounded corners, smooth transitions, and a refined UI
+  - title: Accessible
+    details: Full keyboard navigation, ARIA roles, focus management — works with screen readers out of the box
+  - title: SSR Friendly
+    details: Deterministic first paint, hydration-safe locale detection, single shared MutationObserver
+  - title: Themeable
+    details: Override CSS Variables for colors and sizing — no selector piercing required
 ---
 
 <script setup>
@@ -26,6 +28,7 @@ import { ref } from 'vue'
 const color = ref('#ff0000')
 const englishColor = ref('#3b82f6')
 const japaneseColor = ref('#10b981')
+const topColor = ref('#f59e0b')
 </script>
 
 ## Demo
@@ -52,6 +55,20 @@ const japaneseColor = ref('#10b981')
     :messages="{ moreColors: 'Custom Label...' }"
   />
 </template>
+```
+
+## Placement
+
+The panel auto-detects available viewport space by default. You can lock it to any side with the `placement` prop.
+
+<div class="demo-container">
+  <colorPicker v-model="topColor" placement="top-end" />
+  <p>Pinned to <code>top-end</code>: <code>{{ topColor }}</code></p>
+</div>
+
+```vue
+<colorPicker v-model="color" placement="top-end" />
+<colorPicker v-model="color" placement="bottom" /> <!-- vertical locked, horizontal auto -->
 ```
 
 ## Installation
@@ -87,24 +104,116 @@ const color = ref('#ff0000')
 </script>
 ```
 
-## Options
+## Props
 
 | Prop | Type | Default | Description |
 | --- | --- | --- | --- |
-| `v-model` | `string` | - | Current color value |
-| `defaultColor` | `string` | `#000000` | Default color when reset |
+| `v-model` / `modelValue` | `string` | — | Current color value |
+| `defaultColor` | `string` | `#000000` | Color the "Default" button resets to |
 | `disabled` | `boolean` | `false` | Disabled state |
-| `locale` | `'zh-CN' \| 'en-US' \| 'ja-JP'` | Auto | Built-in locale used by panel labels, follows page language when omitted |
-| `messages` | `Partial<ColorPickerMessages>` | - | Override built-in labels with custom text |
+| `locale` | `'zh-CN' \| 'en-US' \| 'ja-JP'` | Auto | Built-in panel labels; follows `<html lang>` / `navigator.language` when omitted |
+| `messages` | `Partial<ColorPickerMessages>` | — | Override built-in labels with custom text |
+| `placement` | `ColorPickerPlacement` | `'auto'` | Panel placement: `'auto'`, `'top'`, `'bottom'`, `'top-start'`, `'top-end'`, `'bottom-start'`, `'bottom-end'`. `'auto'` picks based on available viewport space; directional values lock that axis |
 
 ## Events
 
 | Event | Payload | Description |
 | --- | --- | --- |
-| `change` | `(color: string)` | Triggered when color value changes |
+| `change` | `(color: string)` | Color value changed |
+| `update:modelValue` | `(color: string)` | `v-model` sync event |
+| `open` | — | Panel opened |
+| `close` | — | Panel closed (outside click, `Esc`, or after selection) |
+| `hover` | `(color: string)` | Swatch hover; emits empty string on leave |
 
 ```vue
 <colorPicker v-model="color" @change="onColorChange" />
+```
+
+## Imperative API
+
+Methods exposed via template ref:
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { ColorPickerInstance } from 'vcolorpicker'
+
+const pickerRef = ref<ColorPickerInstance>()
+const color = ref('#ff0000')
+
+const openProgrammatically = () => pickerRef.value?.open()
+</script>
+
+<template>
+  <colorPicker ref="pickerRef" v-model="color" />
+  <button @click="openProgrammatically">Open Panel</button>
+</template>
+```
+
+| Method | Description |
+| --- | --- |
+| `open()` | Open the panel (no-op when `disabled`) |
+| `close()` | Close the panel |
+| `focus()` | Move focus back to the trigger button |
+
+## Accessibility
+
+- Trigger button and every swatch are reachable via `Tab`
+- `Enter` / `Space` activates; `↑` / `↓` on a focused trigger also opens the panel
+- `Esc` closes the panel and returns focus to the trigger
+- Trigger carries `role="button"`, `aria-haspopup="dialog"`, `aria-expanded`; the panel uses `role="dialog"`; every swatch has `aria-label="#RRGGBB"`
+- Focus rings use `:focus-visible`, so mouse users are not distracted
+
+## SSR / Nuxt
+
+- When `document` / `navigator` are unavailable (Node SSR), the initial locale falls back to `zh-CN` (or the explicit `locale` prop) so server and client render identically — no hydration mismatch
+- Real language detection runs after `onMounted`. To avoid a post-mount flicker from Chinese to another language, **pass an explicit `locale` prop in SSR projects**
+- The `MutationObserver` watching `<html lang>` is a module-level singleton — multiple component instances share a single observer
+
+## CSS Variables
+
+Override these custom properties to theme the component without piercing selectors:
+
+```css
+.m-colorPicker {
+  --vcp-swatch-size: 15px;
+  --vcp-panel-width: 190px;
+  --vcp-panel-bg: #fff;
+  --vcp-panel-border: 1px solid #ddd;
+  --vcp-panel-radius: 2px;
+  --vcp-panel-shadow: 0 8px 24px rgba(0, 0, 0, .18);
+  --vcp-panel-padding: 10px;
+  --vcp-text-color: #333;
+  --vcp-focus-color: #4e81bb;
+  --vcp-transition: .3s ease;
+  --vcp-z-index: 10000;
+}
+```
+
+Example — dark theme:
+
+```css
+.dark .m-colorPicker {
+  --vcp-panel-bg: #1f1f1f;
+  --vcp-panel-border: 1px solid #333;
+  --vcp-text-color: #eee;
+}
+```
+
+## TypeScript
+
+Types exported from the package:
+
+```ts
+import type {
+  ColorPickerProps,
+  ColorPickerEmits,
+  ColorPickerExposed,
+  ColorPickerInstance,
+  ColorPickerLocale,
+  ColorPickerMessages,
+  ColorPickerPlacement
+} from 'vcolorpicker'
 ```
 
 ## FAQ
@@ -119,11 +228,15 @@ Yes. Set `locale="zh-CN"`, `locale="en-US"` or `locale="ja-JP"` to use built-in 
 
 ### Does it work with TypeScript?
 
-Yes. The package ships with TypeScript declaration files for component props and plugin installation.
+Yes. The package ships with full type declarations — props, emits, instance methods, and helper types.
 
 ### Does it support the native browser color picker?
 
 Yes. Clicking `More Colors...` opens the native HTML5 color input in supported browsers.
+
+### Is it accessible to keyboard and screen reader users?
+
+Yes. `Tab` to focus, `Enter` / `Space` to activate, `Esc` to close, and ARIA roles / labels are all wired up.
 
 ## Sponsors
 

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -3,7 +3,7 @@ layout: home
 hero:
   name: vColorPicker
   text: Vue 3 颜色选择器
-  tagline: 轻量、易用的 Vue 3 颜色选择器组件
+  tagline: 轻量、可访问的 Vue 3 颜色选择器组件
   actions:
     - theme: brand
       text: 快速开始
@@ -14,11 +14,13 @@ hero:
 
 features:
   - title: 简单易用
-    details: 简洁的 API，支持 v-model，UI 优化增加了圆角和过渡动画
-  - title: npm 安装
-    details: 以 npm 形式安装，注册为全局组件，可在任何 Vue 3 项目中使用
-  - title: HTML5 取色器
-    details: 在支持的浏览器中通过 HTML5 原生 color input 实现「更多颜色」功能
+    details: 简洁的 v-model API，UI 圆角和过渡动画都已就位
+  - title: 可访问性完善
+    details: 完整的键盘导航、ARIA 角色和焦点管理，开箱即用支持屏幕阅读器
+  - title: SSR 友好
+    details: 首屏渲染确定性，hydration 安全，语言检测延后到挂载之后
+  - title: 主题化
+    details: 通过覆盖 CSS Variables 自定义配色和尺寸，无需选择器穿透
 ---
 
 <script setup>
@@ -26,6 +28,7 @@ import { ref } from 'vue'
 const color = ref('#ff0000')
 const englishColor = ref('#3b82f6')
 const japaneseColor = ref('#10b981')
+const topColor = ref('#f59e0b')
 </script>
 
 ## Demo
@@ -52,6 +55,20 @@ const japaneseColor = ref('#10b981')
     :messages="{ moreColors: '自定义文案...' }"
   />
 </template>
+```
+
+## 面板位置
+
+默认按视口剩余空间自动选位，也可以通过 `placement` 锁定到任意一侧。
+
+<div class="demo-container">
+  <colorPicker v-model="topColor" placement="top-end" />
+  <p>固定到 <code>top-end</code>: <code>{{ topColor }}</code></p>
+</div>
+
+```vue
+<colorPicker v-model="color" placement="top-end" />
+<colorPicker v-model="color" placement="bottom" /> <!-- 锁定向下，水平自动 -->
 ```
 
 <div id="installation"></div>
@@ -89,24 +106,116 @@ const color = ref('#ff0000')
 </script>
 ```
 
-## 选项
+## 属性 Props
 
 | 属性 | 类型 | 默认值 | 说明 |
 | --- | --- | --- | --- |
-| `v-model` | `string` | - | 当前颜色值 |
-| `defaultColor` | `string` | `#000000` | 重置时的默认颜色 |
+| `v-model` / `modelValue` | `string` | — | 当前颜色值 |
+| `defaultColor` | `string` | `#000000` | 「默认颜色」按钮重置使用的颜色 |
 | `disabled` | `boolean` | `false` | 禁用状态 |
-| `locale` | `'zh-CN' \| 'en-US' \| 'ja-JP'` | 自动识别 | 面板内置文案语言，不传时自动跟随当前页面语言 |
-| `messages` | `Partial<ColorPickerMessages>` | - | 用自定义文案覆盖内置语言包 |
+| `locale` | `'zh-CN' \| 'en-US' \| 'ja-JP'` | 自动检测 | 面板内置文案语言；不传时跟随 `<html lang>` / `navigator.language` |
+| `messages` | `Partial<ColorPickerMessages>` | — | 用自定义文案覆盖内置语言包 |
+| `placement` | `ColorPickerPlacement` | `'auto'` | 面板位置：`'auto'` / `'top'` / `'bottom'` / `'top-start'` / `'top-end'` / `'bottom-start'` / `'bottom-end'`。`'auto'` 根据视口剩余空间自动决定；带方向时锁定对应轴 |
 
 ## 事件
 
 | 事件名 | 参数 | 说明 |
 | --- | --- | --- |
 | `change` | `(color: string)` | 颜色值改变时触发 |
+| `update:modelValue` | `(color: string)` | `v-model` 同步事件 |
+| `open` | — | 面板打开时触发 |
+| `close` | — | 面板关闭时触发（点击外部 / Esc / 选色后自动关闭）|
+| `hover` | `(color: string)` | 鼠标移到色块时触发；离开时携带空字符串 |
 
 ```vue
 <colorPicker v-model="color" @change="onColorChange" />
+```
+
+## 命令式 API
+
+通过模板 ref 暴露的方法可命令式控制组件：
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { ColorPickerInstance } from 'vcolorpicker'
+
+const pickerRef = ref<ColorPickerInstance>()
+const color = ref('#ff0000')
+
+const openProgrammatically = () => pickerRef.value?.open()
+</script>
+
+<template>
+  <colorPicker ref="pickerRef" v-model="color" />
+  <button @click="openProgrammatically">打开面板</button>
+</template>
+```
+
+| 方法 | 说明 |
+| --- | --- |
+| `open()` | 打开面板（`disabled` 时无效）|
+| `close()` | 关闭面板 |
+| `focus()` | 把焦点移回触发按钮 |
+
+## 可访问性 (a11y)
+
+- 触发按钮和所有色块都可通过 `Tab` 聚焦
+- `Enter` / `Space` 激活；触发按钮聚焦时按 `↑` / `↓` 也可打开面板
+- 面板打开后按 `Esc` 关闭并把焦点送回触发按钮
+- 触发按钮带 `role="button"` + `aria-haspopup="dialog"` + `aria-expanded`；面板带 `role="dialog"`；每个色块带 `aria-label="#RRGGBB"`
+- 焦点环使用 `:focus-visible`，鼠标用户不会被打扰
+
+## SSR / Nuxt
+
+- 在 Node 环境无 `document` / `navigator` 时，初始 locale 固定为 `zh-CN`（或显式 `locale` prop），保证服务端和客户端首屏一致，无 hydration mismatch
+- 真正的语言检测在 `onMounted` 后才执行。如果要避免挂载后从中文跳变到其他语言的闪动，**建议在 SSR 场景显式传 `locale` prop**
+- 监听 `<html lang>` 变化的 `MutationObserver` 是模块级单例，多实例只占一份资源
+
+## CSS Variables 主题化
+
+无需穿透选择器，覆盖以下变量即可：
+
+```css
+.m-colorPicker {
+  --vcp-swatch-size: 15px;
+  --vcp-panel-width: 190px;
+  --vcp-panel-bg: #fff;
+  --vcp-panel-border: 1px solid #ddd;
+  --vcp-panel-radius: 2px;
+  --vcp-panel-shadow: 0 8px 24px rgba(0, 0, 0, .18);
+  --vcp-panel-padding: 10px;
+  --vcp-text-color: #333;
+  --vcp-focus-color: #4e81bb;
+  --vcp-transition: .3s ease;
+  --vcp-z-index: 10000;
+}
+```
+
+例：暗色主题
+
+```css
+.dark .m-colorPicker {
+  --vcp-panel-bg: #1f1f1f;
+  --vcp-panel-border: 1px solid #333;
+  --vcp-text-color: #eee;
+}
+```
+
+## TypeScript
+
+包内导出的类型：
+
+```ts
+import type {
+  ColorPickerProps,
+  ColorPickerEmits,
+  ColorPickerExposed,
+  ColorPickerInstance,
+  ColorPickerLocale,
+  ColorPickerMessages,
+  ColorPickerPlacement
+} from 'vcolorpicker'
 ```
 
 ## 常见问题
@@ -117,15 +226,19 @@ const color = ref('#ff0000')
 
 ### 可以切换组件面板语言吗？
 
-可以。你可以通过 `locale="zh-CN"`、`locale="en-US"` 或 `locale="ja-JP"` 使用内置文案，也可以通过 `messages` 自定义覆盖面板文字。
+可以。通过 `locale="zh-CN"`、`locale="en-US"` 或 `locale="ja-JP"` 使用内置文案，也可以通过 `messages` 自定义覆盖面板文字。
 
 ### 这个组件支持 TypeScript 吗？
 
-支持。当前包已经包含组件属性和插件注册所需的 TypeScript 类型声明。
+支持。当前包提供完整的类型声明：props、emits、实例方法和辅助类型都有导出。
 
 ### 是否支持浏览器原生取色器？
 
 支持。点击 `更多颜色...` 后，会在兼容浏览器中调用 HTML5 原生取色器。
+
+### 键盘和屏幕阅读器能用吗？
+
+可以。`Tab` 聚焦、`Enter` / `Space` 激活、`Esc` 关闭，ARIA 角色和标签都已配置完整。
 
 ## 赞助
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,14 @@
-import type { DefineComponent, Plugin } from 'vue'
+import type { ComponentPublicInstance, DefineComponent, Plugin } from 'vue'
+
+/**
+ * Public type surface for npm consumers.
+ *
+ * NOTE: these shapes must stay in sync with
+ * `packages/color-picker/src/types.ts` (the canonical source used by the
+ * .vue component itself). The duplication exists because only the files
+ * listed in `package.json#files` ship to npm, and `packages/` is not one
+ * of them.
+ */
 
 export type ColorPickerLocale = 'zh-CN' | 'en-US' | 'ja-JP'
 
@@ -7,7 +17,17 @@ export interface ColorPickerMessages {
   themeColors: string
   standardColors: string
   moreColors: string
+  pickerLabel: string
 }
+
+export type ColorPickerPlacement =
+  | 'auto'
+  | 'top'
+  | 'bottom'
+  | 'top-start'
+  | 'top-end'
+  | 'bottom-start'
+  | 'bottom-end'
 
 export interface ColorPickerProps {
   modelValue: string
@@ -15,7 +35,24 @@ export interface ColorPickerProps {
   disabled?: boolean
   locale?: ColorPickerLocale
   messages?: Partial<ColorPickerMessages>
+  placement?: ColorPickerPlacement
 }
+
+export interface ColorPickerEmits {
+  (e: 'update:modelValue', value: string): void
+  (e: 'change', value: string): void
+  (e: 'open'): void
+  (e: 'close'): void
+  (e: 'hover', color: string): void
+}
+
+export interface ColorPickerExposed {
+  open: () => void
+  close: () => void
+  focus: () => void
+}
+
+export type ColorPickerInstance = ComponentPublicInstance<ColorPickerProps> & ColorPickerExposed
 
 export type ColorPickerComponent = DefineComponent<ColorPickerProps>
 

--- a/packages/color-picker/src/index.vue
+++ b/packages/color-picker/src/index.vue
@@ -1,21 +1,28 @@
 <script lang="ts">
-// 声明无法在 <script setup> 中声明的选项
+// 声明无法在 <script setup> 中声明的选项；本块为模块作用域，常量只初始化一次
+import type {
+  ColorPickerExposed,
+  ColorPickerLocale,
+  ColorPickerMessages,
+  ColorPickerPlacement
+} from './types'
+
 export default {
   name: "colorPicker"
 }
-</script>
 
-<script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, shallowRef, useTemplateRef } from 'vue'
-import { onClickOutside } from '@vueuse/core'
+type ResolvedPlacement = {
+  vertical: 'top' | 'bottom' | 'auto'
+  horizontal: 'left' | 'right' | 'auto'
+}
 
-type ColorPickerLocale = 'zh-CN' | 'en-US' | 'ja-JP'
-
-interface ColorPickerMessages {
-  defaultColor: string
-  themeColors: string
-  standardColors: string
-  moreColors: string
+const parsePlacement = (p: ColorPickerPlacement): ResolvedPlacement => {
+  if (p === 'auto') return { vertical: 'auto', horizontal: 'auto' }
+  const [v, h] = p.split('-') as ['top' | 'bottom', 'start' | 'end' | undefined]
+  return {
+    vertical: v,
+    horizontal: h ? (h === 'start' ? 'left' : 'right') : 'auto'
+  }
 }
 
 const localeMessagesMap: Record<ColorPickerLocale, ColorPickerMessages> = {
@@ -23,47 +30,146 @@ const localeMessagesMap: Record<ColorPickerLocale, ColorPickerMessages> = {
     defaultColor: '默认颜色',
     themeColors: '主题颜色',
     standardColors: '标准颜色',
-    moreColors: '更多颜色...'
+    moreColors: '更多颜色...',
+    pickerLabel: '颜色选择器'
   },
   'en-US': {
     defaultColor: 'Default',
     themeColors: 'Theme Colors',
     standardColors: 'Standard Colors',
-    moreColors: 'More Colors...'
+    moreColors: 'More Colors...',
+    pickerLabel: 'Color picker'
   },
   'ja-JP': {
     defaultColor: 'デフォルトカラー',
     themeColors: 'テーマカラー',
     standardColors: '標準カラー',
-    moreColors: 'その他のカラー...'
+    moreColors: 'その他のカラー...',
+    pickerLabel: 'カラーピッカー'
   }
 }
 
-const normalizeLocale = (locale?: string): ColorPickerLocale => {
-  if (!locale) {
-    return 'zh-CN'
-  }
+// 主题颜色
+const THEME_COLORS = [
+  '#000000', '#ffffff', '#eeece1', '#1e497b', '#4e81bb',
+  '#e2534d', '#9aba60', '#8165a0', '#47acc5', '#f9974c'
+] as const
 
-  const lowerLocale = locale.toLowerCase()
-  if (lowerLocale.startsWith('zh')) return 'zh-CN'
-  if (lowerLocale.startsWith('ja')) return 'ja-JP'
+// 标准颜色
+const STANDARD_COLORS = [
+  '#c21401', '#ff1e02', '#ffc12a', '#ffff3a', '#90cf5b',
+  '#00af57', '#00afee', '#0071be', '#00215f', '#72349d'
+] as const
+
+// 色板渐变源 [深色, 浅色]
+const COLOR_CONFIG: ReadonlyArray<readonly [string, string]> = [
+  ['#7f7f7f', '#f2f2f2'],
+  ['#0d0d0d', '#808080'],
+  ['#1c1a10', '#ddd8c3'],
+  ['#0e243d', '#c6d9f0'],
+  ['#233f5e', '#dae5f0'],
+  ['#632623', '#f2dbdb'],
+  ['#4d602c', '#eaf1de'],
+  ['#3f3150', '#e6e0ec'],
+  ['#1e5867', '#d9eef3'],
+  ['#99490f', '#fee9da']
+]
+
+const GRADIENT_STEPS = 5
+
+const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v))
+
+// 规范化 hex 字符串；非法输入回退到黑色
+const parseColor = (input: string): string => {
+  if (!input || typeof input !== 'string') return '#000000'
+  let hex = input.trim().toLowerCase()
+  if (!hex.startsWith('#')) hex = '#' + hex
+  if (/^#[0-9a-f]{3}$/.test(hex)) {
+    return '#' + hex[1] + hex[1] + hex[2] + hex[2] + hex[3] + hex[3]
+  }
+  if (/^#[0-9a-f]{6}$/.test(hex)) return hex
+  return '#000000'
+}
+
+const hexToRgb = (hex: string): [number, number, number] => {
+  const h = parseColor(hex)
+  return [
+    parseInt(h.slice(1, 3), 16),
+    parseInt(h.slice(3, 5), 16),
+    parseInt(h.slice(5, 7), 16)
+  ]
+}
+
+const rgbToHex = (r: number, g: number, b: number): string => {
+  const toComp = (n: number) => clamp(Math.round(n), 0, 255).toString(16).padStart(2, '0')
+  return '#' + toComp(r) + toComp(g) + toComp(b)
+}
+
+const gradient = (start: string, end: string, step: number): string[] => {
+  const [sr, sg, sb] = hexToRgb(start)
+  const [er, eg, eb] = hexToRgb(end)
+  const rStep = (er - sr) / step
+  const gStep = (eg - sg) / step
+  const bStep = (eb - sb) / step
+  const out: string[] = []
+  for (let i = 0; i < step; i++) {
+    out.push(rgbToHex(sr + rStep * i, sg + gStep * i, sb + bStep * i))
+  }
+  return out
+}
+
+// 预计算一次的渐变面板：浅 -> 深
+const COLOR_PANEL: ReadonlyArray<ReadonlyArray<string>> = COLOR_CONFIG.map(
+  ([dark, light]) => gradient(light, dark, GRADIENT_STEPS)
+)
+
+const normalizeLocale = (locale?: string): ColorPickerLocale => {
+  if (!locale) return 'zh-CN'
+  const l = locale.toLowerCase()
+  if (l.startsWith('zh')) return 'zh-CN'
+  if (l.startsWith('ja')) return 'ja-JP'
   return 'en-US'
 }
 
 const detectLocale = (): ColorPickerLocale => {
   if (typeof document !== 'undefined') {
-    const documentLang = document.documentElement.lang
-    if (documentLang) {
-      return normalizeLocale(documentLang)
-    }
+    const lang = document.documentElement.lang
+    if (lang) return normalizeLocale(lang)
   }
-
-  if (typeof navigator !== 'undefined') {
-    return normalizeLocale(navigator.language)
-  }
-
+  if (typeof navigator !== 'undefined') return normalizeLocale(navigator.language)
   return 'zh-CN'
 }
+
+// MutationObserver 单例：所有组件实例共享一个 observer，引用计数为 0 时断开
+type LangListener = (locale: ColorPickerLocale) => void
+const langListeners = new Set<LangListener>()
+let sharedLangObserver: MutationObserver | null = null
+
+const subscribeLang = (cb: LangListener): (() => void) => {
+  langListeners.add(cb)
+  if (typeof document !== 'undefined' && !sharedLangObserver) {
+    sharedLangObserver = new MutationObserver(() => {
+      const next = detectLocale()
+      langListeners.forEach(fn => fn(next))
+    })
+    sharedLangObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['lang']
+    })
+  }
+  return () => {
+    langListeners.delete(cb)
+    if (langListeners.size === 0 && sharedLangObserver) {
+      sharedLangObserver.disconnect()
+      sharedLangObserver = null
+    }
+  }
+}
+</script>
+
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, shallowRef, useTemplateRef } from 'vue'
+import { onClickOutside } from '@vueuse/core'
 
 const props = withDefaults(defineProps<{
   // 当前颜色
@@ -76,124 +182,70 @@ const props = withDefaults(defineProps<{
   locale?: ColorPickerLocale
   // 自定义文案
   messages?: Partial<ColorPickerMessages>
+  // 面板位置；默认 'auto' 由视口空间决定
+  placement?: ColorPickerPlacement
 }>(), {
   defaultColor: '#000000',
-  messages: () => ({})
+  messages: () => ({}),
+  placement: 'auto'
 })
 
 const emits = defineEmits<{
   (e: 'update:modelValue', value: string): void
   (e: 'change', value: string): void
+  (e: 'open'): void
+  (e: 'close'): void
+  (e: 'hover', color: string): void
 }>()
 
 // 面板状态
 const openStatus = shallowRef(false)
 const panelVerticalPlacement = shallowRef<'bottom' | 'top'>('bottom')
 const panelHorizontalPlacement = shallowRef<'left' | 'right'>('left')
-// 打开面板
-const openPanel = () => {
-  if (props.disabled) {
-    return
-  }
-
-  openStatus.value = !openStatus.value
-
-  if (openStatus.value) {
-    void nextTick(() => {
-      updatePanelPlacement()
-    })
-  }
-}
-const colorPicker = useTemplateRef<HTMLDivElement>('colorPicker')
-const colorPanelEl = useTemplateRef<HTMLDivElement>('colorPanelEl')
-// 关闭面板
-const closePanel = () => {
-  openStatus.value = false
-}
-onClickOutside(colorPicker, closePanel)
-
 // 鼠标经过的颜色块
 const hoverColor = shallowRef('')
-const handleHover = (color: string) => {
-  hoverColor.value = color
-}
-// 主题颜色
-const tColor = ['#000000', '#ffffff', '#eeece1', '#1e497b', '#4e81bb', '#e2534d', '#9aba60', '#8165a0', '#47acc5', '#f9974c']
-// 颜色面板
-const colorConfig = [
-    ['#7f7f7f', '#f2f2f2'],
-    ['#0d0d0d', '#808080'],
-    ['#1c1a10', '#ddd8c3'],
-    ['#0e243d', '#c6d9f0'],
-    ['#233f5e', '#dae5f0'],
-    ['#632623', '#f2dbdb'],
-    ['#4d602c', '#eaf1de'],
-    ['#3f3150', '#e6e0ec'],
-    ['#1e5867', '#d9eef3'],
-    ['#99490f', '#fee9da']
-  ]
-// 标准颜色
-const bColor = ['#c21401', '#ff1e02', '#ffc12a', '#ffff3a', '#90cf5b', '#00af57', '#00afee', '#0071be', '#00215f', '#72349d']
 
-const detectedLocale = shallowRef<ColorPickerLocale>(props.locale ? normalizeLocale(props.locale) : 'zh-CN')
-let documentLangObserver: MutationObserver | null = null
+// SSR 守恒：首屏始终取确定性的 fallback，onMounted 再校准。
+// 当 props.locale 存在时，resolvedLocale 直接走 props，detectedLocale 不参与，
+// 因此这里只需一个稳定的占位值。
+const detectedLocale = shallowRef<ColorPickerLocale>('zh-CN')
 
-onMounted(() => {
-  detectedLocale.value = detectLocale()
-
-  if (typeof document === 'undefined') {
-    return
-  }
-
-  documentLangObserver = new MutationObserver(() => {
-    detectedLocale.value = detectLocale()
-  })
-
-  documentLangObserver.observe(document.documentElement, {
-    attributes: true,
-    attributeFilter: ['lang']
-  })
-
-  window.addEventListener('resize', updatePanelPlacement)
-  window.addEventListener('scroll', updatePanelPlacement, true)
-})
-
-onBeforeUnmount(() => {
-  documentLangObserver?.disconnect()
-  documentLangObserver = null
-  window.removeEventListener('resize', updatePanelPlacement)
-  window.removeEventListener('scroll', updatePanelPlacement, true)
-})
-
-const resolvedLocale = computed<ColorPickerLocale>(() => {
-  return props.locale ? normalizeLocale(props.locale) : detectedLocale.value
-})
+const resolvedLocale = computed<ColorPickerLocale>(() =>
+  props.locale ? normalizeLocale(props.locale) : detectedLocale.value
+)
 
 const resolvedMessages = computed<ColorPickerMessages>(() => ({
   ...localeMessagesMap[resolvedLocale.value],
   ...props.messages
 }))
 
-// 计算属性：显示面板颜色
-const showPanelColor = computed(() => {
-  return hoverColor.value || showColor.value
-})
-// 计算属性：显示颜色
-const showColor = computed(() => {
-  return props.modelValue || props.defaultColor
-})
-// 计算属性：颜色面板
-const colorPanel = computed(() => {
-  const colorArr: string[][] = []
-  for (const color of colorConfig) {
-    colorArr.push(gradient(color[1], color[0], 5))
-  }
-  return colorArr
-})
+const showColor = computed(() => props.modelValue || props.defaultColor)
+const showPanelColor = computed(() => hoverColor.value || showColor.value)
 
+const colorPicker = useTemplateRef<HTMLDivElement>('colorPicker')
+const colorPanelEl = useTemplateRef<HTMLDivElement>('colorPanelEl')
+const triggerEl = useTemplateRef<HTMLDivElement>('triggerEl')
 const html5ColorEl = useTemplateRef<HTMLInputElement>('html5ColorEl')
+
+// rAF 合并的 placement 更新
+let placementRaf = 0
+const schedulePlacementUpdate = () => {
+  if (placementRaf) return
+  placementRaf = requestAnimationFrame(() => {
+    placementRaf = 0
+    updatePanelPlacement()
+  })
+}
+
 const updatePanelPlacement = () => {
-  if (!colorPicker.value || !colorPanelEl.value || !openStatus.value) {
+  if (!colorPicker.value || !colorPanelEl.value || !openStatus.value) return
+
+  const placement = parsePlacement(props.placement)
+
+  // 用户显式锁定的方向直接采用，无需测量
+  if (placement.vertical !== 'auto' && placement.horizontal !== 'auto') {
+    panelVerticalPlacement.value = placement.vertical
+    panelHorizontalPlacement.value = placement.horizontal
     return
   }
 
@@ -207,144 +259,247 @@ const updatePanelPlacement = () => {
   const spaceRight = viewportWidth - triggerRect.left
   const leftAvailableSpace = triggerRect.right
 
-  panelVerticalPlacement.value =
-    panelRect.height > spaceBelow && spaceAbove > spaceBelow ? 'top' : 'bottom'
+  panelVerticalPlacement.value = placement.vertical !== 'auto'
+    ? placement.vertical
+    : (panelRect.height > spaceBelow && spaceAbove > spaceBelow ? 'top' : 'bottom')
 
-  panelHorizontalPlacement.value =
-    panelRect.width > spaceRight && leftAvailableSpace > spaceRight ? 'right' : 'left'
+  panelHorizontalPlacement.value = placement.horizontal !== 'auto'
+    ? placement.horizontal
+    : (panelRect.width > spaceRight && leftAvailableSpace > spaceRight ? 'right' : 'left')
 }
 
-const triggerHtml5Color = () => {
-  html5ColorEl.value?.click()
+const attachViewportListeners = () => {
+  window.addEventListener('resize', schedulePlacementUpdate)
+  window.addEventListener('scroll', schedulePlacementUpdate, true)
 }
+
+const detachViewportListeners = () => {
+  window.removeEventListener('resize', schedulePlacementUpdate)
+  window.removeEventListener('scroll', schedulePlacementUpdate, true)
+  if (placementRaf) {
+    cancelAnimationFrame(placementRaf)
+    placementRaf = 0
+  }
+}
+
+const openPanel = () => {
+  if (props.disabled || openStatus.value) return
+  // 同步先把用户锁定的方向写入，避免首帧 bottom-left → 目标位置闪烁
+  const p = parsePlacement(props.placement)
+  if (p.vertical !== 'auto') panelVerticalPlacement.value = p.vertical
+  if (p.horizontal !== 'auto') panelHorizontalPlacement.value = p.horizontal
+  openStatus.value = true
+  // 完全锁定时视口变化不影响位置，无需挂 viewport listeners
+  const needsAutoMeasure = p.vertical === 'auto' || p.horizontal === 'auto'
+  if (needsAutoMeasure) {
+    attachViewportListeners()
+    void nextTick(updatePanelPlacement)
+  }
+  emits('open')
+}
+
+const closePanel = () => {
+  if (!openStatus.value) return
+  openStatus.value = false
+  detachViewportListeners()
+  emits('close')
+}
+
+const togglePanel = () => {
+  if (props.disabled) return
+  if (openStatus.value) closePanel()
+  else openPanel()
+}
+
+onClickOutside(colorPicker, closePanel)
+
+const focusTrigger = () => {
+  void nextTick(() => triggerEl.value?.focus())
+}
+
 // 更新组件的值
 const updateValue = (value: string) => {
   emits('update:modelValue', value)
   emits('change', value)
-  openStatus.value = false
-}
-// 设置默认颜色
-const handleDefaultColor = () => {
-  updateValue(props.defaultColor)
+  closePanel()
+  focusTrigger()
 }
 
+const handleDefaultColor = () => updateValue(props.defaultColor)
+const handleHover = (color: string) => {
+  hoverColor.value = color
+  emits('hover', color)
+}
+const triggerHtml5Color = () => html5ColorEl.value?.click()
 const handleHtml5ColorChange = (event: Event) => {
-  const value = (event.target as HTMLInputElement).value
-  updateValue(value)
+  updateValue((event.target as HTMLInputElement).value)
 }
 
-/**
- * 颜色计算
- */
-// 格式化 hex 颜色值
-const parseColor = (hexStr: string) => {
-  if (hexStr.length === 4) {
-    return '#' + hexStr[1] + hexStr[1] + hexStr[2] + hexStr[2] + hexStr[3] + hexStr[3]
-  } else {
-    return hexStr
+// 键盘交互
+const onTriggerKeydown = (e: KeyboardEvent) => {
+  if (props.disabled) return
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault()
+    togglePanel()
+  } else if (e.key === 'Escape' && openStatus.value) {
+    e.preventDefault()
+    closePanel()
+  } else if ((e.key === 'ArrowDown' || e.key === 'ArrowUp') && !openStatus.value) {
+    e.preventDefault()
+    openPanel()
   }
 }
-// RGB 颜色 转 HEX 颜色
-const rgbToHex = (r: number, g: number, b: number) => {
-  const hex = ((r << 16) | (g << 8) | b).toString(16)
-  return '#' + new Array(Math.abs(hex.length - 7)).join('0') + hex
-}
-// HEX 转 RGB 颜色
-const hexToRgb = (hex: string) => {
-  hex = parseColor(hex)
-  const rgb = []
-  for (let i = 1; i < 7; i += 2) {
-    rgb.push(parseInt('0x' + hex.slice(i, i + 2)))
+
+const onPanelKeydown = (e: KeyboardEvent) => {
+  if (e.key === 'Escape') {
+    e.preventDefault()
+    closePanel()
+    focusTrigger()
   }
-  return rgb
 }
-// 计算渐变过渡颜色
-const gradient = (startColor: string, endColor: string, step: number) => {
-  // 讲 hex 转换为 rgb
-  const sColor = hexToRgb(startColor)
-  const eColor = hexToRgb(endColor)
-  // 计算R\G\B每一步的差值
-  const rStep = (eColor[0] - sColor[0]) / step
-  const gStep = (eColor[1] - sColor[1]) / step
-  const bStep = (eColor[2] - sColor[2]) / step
-  const gradientColorArr = []
-  // 计算每一步的hex值
-  for (let i = 0; i < step; i++) {
-    gradientColorArr.push(rgbToHex(rStep * i + sColor[0], gStep * i + sColor[1], bStep * i + sColor[2]))
+
+const onActivate = (e: KeyboardEvent, handler: () => void) => {
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault()
+    handler()
   }
-  return gradientColorArr
 }
+
+let unsubscribeLang: (() => void) | null = null
+
+onMounted(() => {
+  if (!props.locale) detectedLocale.value = detectLocale()
+  unsubscribeLang = subscribeLang((next) => {
+    if (!props.locale) detectedLocale.value = next
+  })
+})
+
+onBeforeUnmount(() => {
+  unsubscribeLang?.()
+  unsubscribeLang = null
+  detachViewportListeners()
+})
+
+defineExpose<ColorPickerExposed>({
+  open: openPanel,
+  close: closePanel,
+  focus: () => triggerEl.value?.focus()
+})
 </script>
 
 <template>
-  <div class="m-colorPicker" :class="{ open: openStatus }" ref="colorPicker" @click="event => { event.stopPropagation() }">
-    <!-- 颜色显示小方块 -->
-    <div class="colorBtn"
-      :style="`background-color: ${showColor}`"
-      @click="openPanel"
-      :class="{ disabled: disabled }"
+  <div class="m-colorPicker" :class="{ open: openStatus }" ref="colorPicker">
+    <!-- 颜色显示小方块（兼具触发按钮） -->
+    <div
+      ref="triggerEl"
+      class="colorBtn"
+      role="button"
+      :tabindex="disabled ? -1 : 0"
+      aria-haspopup="dialog"
+      :aria-expanded="openStatus"
+      :aria-disabled="disabled || undefined"
+      :aria-label="`${resolvedMessages.pickerLabel}, ${showColor}`"
+      :style="{ backgroundColor: showColor }"
+      :class="{ disabled }"
+      @click="togglePanel"
+      @keydown="onTriggerKeydown"
     ></div>
     <!-- 颜色色盘 -->
     <div
       ref="colorPanelEl"
       class="box"
+      role="dialog"
+      aria-modal="false"
+      :aria-hidden="!openStatus"
+      :aria-label="resolvedMessages.pickerLabel"
       :class="{
         open: openStatus,
         'placement-top': panelVerticalPlacement === 'top',
         'placement-right': panelHorizontalPlacement === 'right'
       }"
+      @keydown="onPanelKeydown"
     >
       <div class="hd">
         <div class="colorView" :style="{ backgroundColor: showPanelColor }"></div>
-        <div class="defaultColor"
+        <div
+          class="defaultColor"
+          role="button"
+          tabindex="0"
           @click="handleDefaultColor"
+          @keydown="(e) => onActivate(e, handleDefaultColor)"
           @mouseover="handleHover(defaultColor)"
           @mouseout="handleHover('')"
         >{{ resolvedMessages.defaultColor }}</div>
       </div>
       <div class="bd">
         <h3>{{ resolvedMessages.themeColors }}</h3>
-        <ul class="tColor">
+        <ul class="tColor" role="grid">
           <li
-            v-for="(color, index) of tColor"
+            v-for="(color, index) of THEME_COLORS"
             :key="index"
+            role="gridcell"
+            tabindex="0"
+            :aria-label="color"
             :style="{ backgroundColor: color }"
             @mouseover="handleHover(color)"
             @mouseout="handleHover('')"
             @click="updateValue(color)"
+            @keydown="(e) => onActivate(e, () => updateValue(color))"
           ></li>
         </ul>
-        <ul class="bColor">
-          <li v-for="(item, index) of colorPanel" :key="index">
+        <ul class="bColor" role="grid">
+          <li v-for="(item, index) of COLOR_PANEL" :key="index" role="row">
             <ul>
               <li
                 v-for="(color, cindex) of item"
                 :key="cindex"
+                role="gridcell"
+                tabindex="0"
+                :aria-label="color"
                 :style="{ backgroundColor: color }"
                 @mouseover="handleHover(color)"
                 @mouseout="handleHover('')"
                 @click="updateValue(color)"
+                @keydown="(e) => onActivate(e, () => updateValue(color))"
               ></li>
             </ul>
           </li>
         </ul>
         <h3>{{ resolvedMessages.standardColors }}</h3>
-        <ul class="tColor">
+        <ul class="tColor" role="grid">
           <li
-            v-for="(color, index) of bColor"
+            v-for="(color, index) of STANDARD_COLORS"
             :key="index"
+            role="gridcell"
+            tabindex="0"
+            :aria-label="color"
             :style="{ backgroundColor: color }"
             @mouseover="handleHover(color)"
             @mouseout="handleHover('')"
             @click="updateValue(color)"
+            @keydown="(e) => onActivate(e, () => updateValue(color))"
           ></li>
         </ul>
-        <h3 @click="triggerHtml5Color">{{ resolvedMessages.moreColors }}</h3>
-        <!-- 用以激活HTML5颜色面板 -->
-        <input type="color"
+        <h3
+          class="moreColors"
+          role="button"
+          tabindex="0"
+          @click="triggerHtml5Color"
+          @keydown="(e) => onActivate(e, triggerHtml5Color)"
+        >{{ resolvedMessages.moreColors }}</h3>
+        <!--
+          用以激活 HTML5 原生颜色面板。
+          监听 @change（用户在原生面板里点确定）而非 @input（拖动持续触发），
+          避免拖动时反复 emit + focusTrigger 抢焦点。
+        -->
+        <input
+          type="color"
           ref="html5ColorEl"
+          aria-hidden="true"
+          tabindex="-1"
           :value="showColor"
-          @input="handleHtml5ColorChange">
+          @change="handleHtml5ColorChange"
+        >
       </div>
     </div>
   </div>
@@ -352,18 +507,41 @@ const gradient = (startColor: string, endColor: string, step: number) => {
 
 <style lang="scss">
 .m-colorPicker{
+  // CSS Variables - 可被外部覆盖以定制主题
+  --vcp-swatch-size: 15px;
+  --vcp-panel-width: 190px;
+  --vcp-panel-bg: #fff;
+  --vcp-panel-border: 1px solid #ddd;
+  --vcp-panel-radius: 2px;
+  --vcp-panel-shadow: 0 8px 24px rgba(0, 0, 0, .18);
+  --vcp-panel-padding: 10px;
+  --vcp-text-color: #333;
+  --vcp-focus-color: #4e81bb;
+  --vcp-transition: .3s ease;
+  --vcp-z-index: 10000;
+
   position: relative; text-align: left; font-size: 14px; display: inline-block;
   outline: none;
   ul,li,ol{ list-style: none; margin: 0; padding: 0; }
-  .colorBtn{ width: 15px; height: 15px; }
+  .colorBtn{ width: var(--vcp-swatch-size); height: var(--vcp-swatch-size); cursor: pointer; }
   .colorBtn.disabled{ cursor: no-drop; }
-  &.open{ z-index: 10000; }
+  .colorBtn:focus-visible{ outline: 2px solid var(--vcp-focus-color); outline-offset: 2px; }
+  &.open{ z-index: var(--vcp-z-index); }
   .box{
-    position: absolute; top: calc(100% + 2px); left: 0; width: 190px; background: #fff; border: 1px solid #ddd; visibility: hidden; border-radius: 2px; margin-top: 0; padding: 10px; padding-bottom: 5px; box-shadow: 0 8px 24px rgba(0,0,0,.18); opacity: 0; transition: all .3s ease;
+    position: absolute; top: calc(100% + 2px); left: 0;
+    width: var(--vcp-panel-width);
+    background: var(--vcp-panel-bg);
+    border: var(--vcp-panel-border);
+    border-radius: var(--vcp-panel-radius);
+    box-shadow: var(--vcp-panel-shadow);
+    padding: var(--vcp-panel-padding); padding-bottom: 5px;
+    visibility: hidden; margin-top: 0; opacity: 0; transition: all var(--vcp-transition);
     box-sizing: content-box;
     z-index: 1;
     pointer-events: none;
-    h3{ margin: 0; font-size: 14px; font-weight: normal; margin-top: 10px; margin-bottom: 5px; line-height: 1; color: #333; }
+    h3{ margin: 0; font-size: 14px; font-weight: normal; margin-top: 10px; margin-bottom: 5px; line-height: 1; color: var(--vcp-text-color); }
+    h3.moreColors{ cursor: pointer; }
+    h3.moreColors:focus-visible{ outline: 1px dashed var(--vcp-focus-color); outline-offset: 2px; }
     input {
       visibility: hidden;
       position: absolute;
@@ -376,18 +554,21 @@ const gradient = (startColor: string, endColor: string, step: number) => {
   .box.open{ visibility: visible; opacity: 1; pointer-events: auto; }
   .hd{
     overflow: hidden; line-height: 29px;
-    .colorView{ width: 100px; height: 30px; float: left; transition: background-color .3s ease; }
-    .defaultColor{ width: 80px; float: right; text-align: center; border: 1px solid #ddd; cursor: pointer; color: #333; }
+    .colorView{ width: 100px; height: 30px; float: left; transition: background-color var(--vcp-transition); }
+    .defaultColor{ width: 80px; float: right; text-align: center; border: var(--vcp-panel-border); cursor: pointer; color: var(--vcp-text-color); box-sizing: border-box; }
+    .defaultColor:focus-visible{ outline: 2px solid var(--vcp-focus-color); outline-offset: 1px; }
   }
   .tColor{
-    li{ width: 15px; height: 15px; display: inline-block; margin: 0 2px; transition: all .3s ease; }
+    li{ width: var(--vcp-swatch-size); height: var(--vcp-swatch-size); display: inline-block; margin: 0 2px; transition: all var(--vcp-transition); cursor: pointer; }
     li:hover{ box-shadow: 0 0 5px rgba(0,0,0,.4); transform: scale(1.3); }
+    li:focus-visible{ outline: none; box-shadow: 0 0 0 2px var(--vcp-focus-color); position: relative; z-index: 1; }
   }
   .bColor{
     li{
-      width: 15px; display: inline-block; margin: 0 2px;
-      li{ display: block; width: 15px; height: 15px; transition: all .3s ease; margin: 0; }
+      width: var(--vcp-swatch-size); display: inline-block; margin: 0 2px;
+      li{ display: block; width: var(--vcp-swatch-size); height: var(--vcp-swatch-size); transition: all var(--vcp-transition); margin: 0; cursor: pointer; }
       li:hover{ box-shadow: 0 0 5px rgba(0,0,0,.4); transform: scale(1.3); }
+      li:focus-visible{ outline: none; box-shadow: 0 0 0 2px var(--vcp-focus-color); position: relative; z-index: 1; }
     }
   }
 }

--- a/packages/color-picker/src/types.ts
+++ b/packages/color-picker/src/types.ts
@@ -1,0 +1,31 @@
+/**
+ * Canonical type definitions for vcolorpicker.
+ *
+ * NOTE: index.d.ts at the repo root re-declares the same shapes for npm
+ * consumers (since the source tree is not shipped). Keep both files in sync.
+ */
+
+export type ColorPickerLocale = 'zh-CN' | 'en-US' | 'ja-JP'
+
+export interface ColorPickerMessages {
+  defaultColor: string
+  themeColors: string
+  standardColors: string
+  moreColors: string
+  pickerLabel: string
+}
+
+export type ColorPickerPlacement =
+  | 'auto'
+  | 'top'
+  | 'bottom'
+  | 'top-start'
+  | 'top-end'
+  | 'bottom-start'
+  | 'bottom-end'
+
+export interface ColorPickerExposed {
+  open: () => void
+  close: () => void
+  focus: () => void
+}


### PR DESCRIPTION
## Summary

Backwards-compatible refactor of `packages/color-picker` covering accessibility, performance, theming, and a handful of subtle bugs. All existing `v-model` / `change` / `defaultColor` / `disabled` / `locale` / `messages` behavior is preserved — no breaking changes.

## What changed

### Accessibility
- Trigger and every swatch are keyboard-reachable via `Tab` and activatable with `Enter` / `Space`; `ArrowUp` / `ArrowDown` on the trigger also opens the panel.
- `Esc` closes the panel and returns focus to the trigger.
- Roles / ARIA wired up: trigger has `role=button` + `aria-haspopup=dialog` + `aria-expanded`; panel has `role=dialog` + `aria-modal=false`; swatches have `role=gridcell` + `aria-label=\"#RRGGBB\"`.
- Hidden `<input type=\"color\">` carries `aria-hidden=\"true\"` + `tabindex=\"-1\"` to stay out of the a11y tree.
- New `pickerLabel` message powers a natural trigger label (`Color picker, #ff0000`).
- Focus rings use `:focus-visible`; swatch focus uses `box-shadow` so it tracks `transform: scale(1.3)` cleanly.

### Performance / memory
- Static color data (`THEME_COLORS`, `STANDARD_COLORS`, `COLOR_CONFIG`, precomputed `COLOR_PANEL`) hoisted to module scope — no per-instance allocations; the gradient matrix runs **once** at module load.
- `MutationObserver` watching `<html lang>` is now a **module-level singleton** with refcount, shared across instances.
- `resize` / `scroll` listeners attach **only while the panel is open**, are coalesced through `requestAnimationFrame`, and are skipped entirely when `placement` is fully locked.

### Robustness fixes
- HTML5 color input listens to `@change` instead of `@input` — fixes reentrant `updateValue` + focus stealing while the user drags the native picker.
- `openPanel` applies the user's locked `placement` **synchronously** before measuring, eliminating the first-frame bottom-left → target-placement flash.
- `parseColor` trims, lowercases, and falls back to `#000000` on invalid input; `rgbToHex` uses `Math.round` + `clamp(0,255)` + `padStart(2,'0')` instead of the older bit-shift + `Array.join` padding.

### Additive API (no breaking changes)
- New prop `placement`: `'auto' | 'top' | 'bottom' | 'top-start' | 'top-end' | 'bottom-start' | 'bottom-end'` (default `'auto'`).
- New emits: `open`, `close`, `hover(color)`.
- `defineExpose` exposes `open()`, `close()`, `focus()` for imperative use.
- CSS Variables for theming (`--vcp-panel-bg`, `--vcp-focus-color`, `--vcp-swatch-size`, …).
- `pickerLabel` added to `ColorPickerMessages`. Consumers passing `Partial<ColorPickerMessages>` are unaffected — built-in defaults fill the gap.

### Types
- New `packages/color-picker/src/types.ts` is the canonical source for `ColorPickerLocale` / `ColorPickerMessages` / `ColorPickerPlacement` / `ColorPickerExposed`; the component imports from it.
- Root `index.d.ts` mirrors the same shapes (because `packages/` isn't in `package.json#files`) and carries a sync-note in the header.

### Docs
- `README.md`, `docs/index.md`, `docs/zh/index.md` updated with new props/events, expose API, accessibility section, SSR guidance, CSS Variables reference, and TypeScript exports.

## Bundle size

| Artifact | Before (this branch's base) | After | Δ |
|---|---:|---:|---:|
| `lib/vcolorpicker.js` | 10.5 kB | 13.5 kB | +3.0 kB |
| `lib/vcolorpicker.js` (gzip) | 4.05 kB | 4.97 kB | +0.92 kB |
| `lib/vcolorpicker.css` | 1.7 kB | 3.0 kB | +1.3 kB |

The JS growth comes from a11y attributes / keyboard handlers / placement parsing / pickerLabel strings; CSS growth is the CSS Variables block and focus-visible rules.

## Test plan

- [x] `pnpm run type-check` — passes
- [x] `pnpm run lint` — passes
- [x] `pnpm run lib` (vite build) — passes
- [x] `pnpm run docs:build` — passes
- [ ] Manual: keyboard nav (Tab / Enter / Space / Esc / Arrow keys) in `pnpm run docs:dev`
- [ ] Manual: confirm `placement` demo doesn't get clipped at the top of the docs page
- [ ] Manual: drag native HTML5 color picker — should only emit once on confirm, no focus jitter
- [ ] Manual: dark-theme override via CSS Variables in a consumer app
- [ ] Manual: SSR/Nuxt smoke test (no hydration mismatch warnings)

## Reviewer notes

- Hand-maintained `index.d.ts` is a duplication hazard but is structurally required (only files in `package.json#files` ship to npm, and `packages/` isn't one of them). The header comment in both files calls out the sync requirement. Switching to vue-tsc-generated d.ts is a separate task.
- The trigger remains a styled `<div>` (with `role=\"button\"`) rather than a `<button>` to avoid touching existing CSS that consumers may rely on.
- Full grid arrow-key navigation across the swatch panel (popper/menu-style 2-D motion) is intentionally left out — basic Tab + Enter / Space already covers the WCAG baseline. Happy to do it in a follow-up if desired.