### PR TITLE
feat(color-picker): teleport 支持、色板键盘导航与工程化全面优化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm exec eslint .
+
+      - name: Type check
+        run: pnpm run type-check
+
+      - name: Unit tests
+        run: pnpm run test
+
+      - name: Build library
+        run: pnpm run lib

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Vue.use(vcolorpicker)
 | `locale` | `'zh-CN' \| 'en-US' \| 'ja-JP'` | 自动检测 | 面板内置文案语言；不传时跟随 `<html lang>` / `navigator.language` |
 | `messages` | `Partial<ColorPickerMessages>` | — | 自定义文案对象，覆盖 `defaultColor` / `themeColors` / `standardColors` / `moreColors` |
 | `placement` | `ColorPickerPlacement` | `'auto'` | 面板位置：`'auto'` / `'top'` / `'bottom'` / `'top-start'` / `'top-end'` / `'bottom-start'` / `'bottom-end'`。`'auto'` 根据视口剩余空间自动决定；带方向时锁定对应轴 |
+| `teleport` | `boolean \| string` | `false` | 把面板渲染到 `body`（`true`）或 CSS 选择器指定的容器，避免被祖先 `overflow: hidden` 裁剪 |
 
 ## 事件
 
@@ -148,8 +149,8 @@ const openProgrammatically = () => pickerRef.value?.open()
 
 ## 可访问性（a11y）
 
-- 触发按钮和所有色块都可通过 `Tab` 聚焦
-- `Enter` / `Space` 激活；触发按钮聚焦时按 `↑` / `↓` 也可打开面板
+- 触发按钮可通过 `Tab` 聚焦；`Enter` / `Space` 激活；触发按钮聚焦时按 `↑` / `↓` 打开面板并聚焦第一个色块
+- 色块网格采用漫游焦点（roving tabindex）：`Tab` 一次进入网格，之后用 `←` `→` `↑` `↓` 在色块间移动，`Home` / `End` 跳到行首 / 行尾，`Enter` / `Space` 选中
 - 面板打开后按 `Esc` 关闭并把焦点送回触发按钮
 - 触发按钮带 `role="button"` + `aria-haspopup="dialog"` + `aria-expanded`，面板带 `role="dialog"`，每个色块带 `aria-label="#RRGGBB"`
 - 焦点环使用 `:focus-visible`，鼠标用户不会被打扰

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -11,7 +11,7 @@ const ENGLISH_FAQ = [
   },
   {
     question: 'Can I customize the panel text or change the language?',
-    answer: 'Yes. You can set the locale prop to zh-CN or en-US, and you can override built-in labels with the messages prop.'
+    answer: 'Yes. You can set the locale prop to zh-CN, en-US or ja-JP, and you can override built-in labels with the messages prop.'
   },
   {
     question: 'Does the color picker work with TypeScript?',
@@ -29,7 +29,7 @@ const CHINESE_FAQ = [
   },
   {
     question: '可以切换中英文或者自定义面板文案吗？',
-    answer: '可以。你可以通过 locale 设置 zh-CN 或 en-US，也可以通过 messages 覆盖默认文案。'
+    answer: '可以。你可以通过 locale 设置 zh-CN、en-US 或 ja-JP，也可以通过 messages 覆盖默认文案。'
   },
   {
     question: '这个组件支持 TypeScript 吗？',

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,6 +71,15 @@ The panel auto-detects available viewport space by default. You can lock it to a
 <colorPicker v-model="color" placement="bottom" /> <!-- vertical locked, horizontal auto -->
 ```
 
+## Teleport
+
+When the picker sits inside a container with `overflow: hidden` (tables, dialogs, cards), the panel can get clipped. Set `teleport` to render the panel into `document.body` (or any CSS selector) with fixed positioning that tracks the trigger on scroll and resize.
+
+```vue
+<colorPicker v-model="color" teleport />
+<colorPicker v-model="color" teleport="#popup-root" />
+```
+
 ## Installation
 
 ```bash
@@ -114,6 +123,7 @@ const color = ref('#ff0000')
 | `locale` | `'zh-CN' \| 'en-US' \| 'ja-JP'` | Auto | Built-in panel labels; follows `<html lang>` / `navigator.language` when omitted |
 | `messages` | `Partial<ColorPickerMessages>` | — | Override built-in labels with custom text |
 | `placement` | `ColorPickerPlacement` | `'auto'` | Panel placement: `'auto'`, `'top'`, `'bottom'`, `'top-start'`, `'top-end'`, `'bottom-start'`, `'bottom-end'`. `'auto'` picks based on available viewport space; directional values lock that axis |
+| `teleport` | `boolean \| string` | `false` | Render the panel into `body` (`true`) or a CSS selector target, escaping `overflow: hidden` ancestors |
 
 ## Events
 
@@ -158,8 +168,8 @@ const openProgrammatically = () => pickerRef.value?.open()
 
 ## Accessibility
 
-- Trigger button and every swatch are reachable via `Tab`
-- `Enter` / `Space` activates; `↑` / `↓` on a focused trigger also opens the panel
+- Trigger button is reachable via `Tab`; `Enter` / `Space` activates; `↑` / `↓` on a focused trigger opens the panel and focuses the first swatch
+- The swatch grid uses a roving tabindex: `Tab` enters the grid once, then `←` `→` `↑` `↓` move between swatches, `Home` / `End` jump within a row, `Enter` / `Space` selects
 - `Esc` closes the panel and returns focus to the trigger
 - Trigger carries `role="button"`, `aria-haspopup="dialog"`, `aria-expanded`; the panel uses `role="dialog"`; every swatch has `aria-label="#RRGGBB"`
 - Focus rings use `:focus-visible`, so mouse users are not distracted
@@ -199,6 +209,8 @@ Example — dark theme:
   --vcp-text-color: #eee;
 }
 ```
+
+> With `teleport` enabled the panel is no longer a descendant of `.m-colorPicker`, so also override `.m-colorPicker-box` (the panel root) — or define the variables on `:root` to cover both.
 
 ## TypeScript
 

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -71,6 +71,15 @@ const topColor = ref('#f59e0b')
 <colorPicker v-model="color" placement="bottom" /> <!-- 锁定向下，水平自动 -->
 ```
 
+## Teleport 传送
+
+当组件位于 `overflow: hidden` 的容器（表格、弹窗、卡片）内时，面板可能被裁剪。设置 `teleport` 可把面板渲染到 `document.body`（或任意 CSS 选择器目标），使用 fixed 定位并在滚动 / 缩放时自动跟随触发器。
+
+```vue
+<colorPicker v-model="color" teleport />
+<colorPicker v-model="color" teleport="#popup-root" />
+```
+
 <div id="installation"></div>
 
 ## 安装
@@ -116,6 +125,7 @@ const color = ref('#ff0000')
 | `locale` | `'zh-CN' \| 'en-US' \| 'ja-JP'` | 自动检测 | 面板内置文案语言；不传时跟随 `<html lang>` / `navigator.language` |
 | `messages` | `Partial<ColorPickerMessages>` | — | 用自定义文案覆盖内置语言包 |
 | `placement` | `ColorPickerPlacement` | `'auto'` | 面板位置：`'auto'` / `'top'` / `'bottom'` / `'top-start'` / `'top-end'` / `'bottom-start'` / `'bottom-end'`。`'auto'` 根据视口剩余空间自动决定；带方向时锁定对应轴 |
+| `teleport` | `boolean \| string` | `false` | 把面板渲染到 `body`（`true`）或 CSS 选择器指定的容器，避免被祖先 `overflow: hidden` 裁剪 |
 
 ## 事件
 
@@ -160,8 +170,8 @@ const openProgrammatically = () => pickerRef.value?.open()
 
 ## 可访问性 (a11y)
 
-- 触发按钮和所有色块都可通过 `Tab` 聚焦
-- `Enter` / `Space` 激活；触发按钮聚焦时按 `↑` / `↓` 也可打开面板
+- 触发按钮可通过 `Tab` 聚焦；`Enter` / `Space` 激活；触发按钮聚焦时按 `↑` / `↓` 打开面板并聚焦第一个色块
+- 色块网格采用漫游焦点（roving tabindex）：`Tab` 一次进入网格，之后用 `←` `→` `↑` `↓` 在色块间移动，`Home` / `End` 跳到行首 / 行尾，`Enter` / `Space` 选中
 - 面板打开后按 `Esc` 关闭并把焦点送回触发按钮
 - 触发按钮带 `role="button"` + `aria-haspopup="dialog"` + `aria-expanded`；面板带 `role="dialog"`；每个色块带 `aria-label="#RRGGBB"`
 - 焦点环使用 `:focus-visible`，鼠标用户不会被打扰
@@ -201,6 +211,8 @@ const openProgrammatically = () => pickerRef.value?.open()
   --vcp-text-color: #eee;
 }
 ```
+
+> 开启 `teleport` 后面板不再是 `.m-colorPicker` 的后代节点，主题变量需要同时覆盖 `.m-colorPicker-box`（面板根节点），或直接定义在 `:root` 上一次覆盖两者。
 
 ## TypeScript
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,11 +3,9 @@ import type { ComponentPublicInstance, DefineComponent, Plugin } from 'vue'
 /**
  * Public type surface for npm consumers.
  *
- * NOTE: these shapes must stay in sync with
- * `packages/color-picker/src/types.ts` (the canonical source used by the
- * .vue component itself). The duplication exists because only the files
- * listed in `package.json#files` ship to npm, and `packages/` is not one
- * of them.
+ * This is the canonical declaration file (the only one shipped to npm);
+ * `packages/color-picker/src/types.ts` re-exports the shared shapes from
+ * here, so the two can never drift apart.
  */
 
 export type ColorPickerLocale = 'zh-CN' | 'en-US' | 'ja-JP'
@@ -36,6 +34,8 @@ export interface ColorPickerProps {
   locale?: ColorPickerLocale
   messages?: Partial<ColorPickerMessages>
   placement?: ColorPickerPlacement
+  /** Render the panel into a container (true = body) to escape overflow clipping */
+  teleport?: boolean | string
 }
 
 export interface ColorPickerEmits {

--- a/package.json
+++ b/package.json
@@ -16,11 +16,20 @@
   ],
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./lib/vcolorpicker.js",
-      "require": "./lib/vcolorpicker.umd.cjs",
-      "types": "./index.d.ts"
+      "require": "./lib/vcolorpicker.umd.cjs"
     },
-    "./style.css": "./lib/vcolorpicker.css"
+    "./style.css": "./lib/vcolorpicker.css",
+    "./package.json": "./package.json"
+  },
+  "unpkg": "./lib/vcolorpicker.umd.cjs",
+  "jsdelivr": "./lib/vcolorpicker.umd.cjs",
+  "sideEffects": [
+    "**/*.css"
+  ],
+  "engines": {
+    "node": ">=20.19.0"
   },
   "keywords": [
     "vcolorpicker",
@@ -43,37 +52,37 @@
   "private": false,
   "scripts": {
     "dev": "vitepress dev docs",
-    "build": "run-p type-check build-only",
+    "build": "run-s type-check lib",
     "lib": "vite build --mode lib",
-    "preview": "vite preview",
-    "build-only": "vite build",
     "type-check": "vue-tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "eslint . --fix",
-    "format": "prettier --write src/",
+    "format": "prettier --write packages/ docs/",
     "commit": "git-cz",
     "release": "release-it",
+    "prepublishOnly": "run-s type-check test lib",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs"
   },
-  "dependencies": {
-    "@vueuse/core": "^14.3.0",
-    "highlight.js": "^11.11.1",
-    "vue": "^3.5.33"
+  "peerDependencies": {
+    "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@release-it/conventional-changelog": "^11.0.0",
     "@types/node": "^25.6.0",
-    "@types/web-bluetooth": "^0.0.21",
     "@vitejs/plugin-vue": "^6.0.6",
     "@vue/eslint-config-prettier": "^10.2.0",
     "@vue/eslint-config-typescript": "^14.7.0",
     "@vue/server-renderer": "^3.5.34",
+    "@vue/test-utils": "^2.4.11",
     "@vue/tsconfig": "^0.9.1",
     "eslint": "^10.3.0",
     "eslint-plugin-vue": "^10.9.0",
     "git-cz": "^4.9.0",
+    "jsdom": "^29.1.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.8.3",
     "release-it": "^20.0.1",
@@ -81,6 +90,8 @@
     "typescript": "~5.8.3",
     "vite": "^8.0.10",
     "vitepress": "^1.6.4",
+    "vitest": "^4.1.10",
+    "vue": "^3.5.33",
     "vue-tsc": "^3.2.7"
   },
   "release-it": {

--- a/packages/color-picker/__tests__/index.spec.ts
+++ b/packages/color-picker/__tests__/index.spec.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import colorPicker from '../src/index.vue'
+
+let wrapper: VueWrapper | null = null
+
+const mountPicker = (props: Record<string, unknown> = {}) => {
+  wrapper = mount(colorPicker, {
+    props: { modelValue: '#ff0000', ...props },
+    attachTo: document.body
+  })
+  return wrapper
+}
+
+afterEach(() => {
+  wrapper?.unmount()
+  wrapper = null
+  document.body.innerHTML = ''
+})
+
+describe('colorPicker 基础渲染', () => {
+  it('触发器显示当前颜色', () => {
+    const w = mountPicker()
+    const btn = w.get('.colorBtn')
+    expect(btn.attributes('style')).toContain('background-color: rgb(255, 0, 0)')
+  })
+
+  it('modelValue 为空时显示 defaultColor', () => {
+    const w = mountPicker({ modelValue: '', defaultColor: '#00ff00' })
+    expect(w.get('.colorBtn').attributes('style')).toContain('rgb(0, 255, 0)')
+  })
+
+  it('locale 为 en-US 时渲染英文文案', () => {
+    const w = mountPicker({ locale: 'en-US' })
+    expect(w.get('.defaultColor').text()).toBe('Default')
+    expect(w.text()).toContain('Theme Colors')
+  })
+})
+
+describe('面板开关', () => {
+  it('点击触发器打开面板并触发 open 事件', async () => {
+    const w = mountPicker()
+    await w.get('.colorBtn').trigger('click')
+    expect(w.get('.box').classes()).toContain('open')
+    expect(w.emitted('open')).toHaveLength(1)
+  })
+
+  it('disabled 时点击不打开', async () => {
+    const w = mountPicker({ disabled: true })
+    await w.get('.colorBtn').trigger('click')
+    expect(w.get('.box').classes()).not.toContain('open')
+    expect(w.emitted('open')).toBeUndefined()
+  })
+
+  it('面板内按 Escape 关闭并触发 close 事件', async () => {
+    const w = mountPicker()
+    await w.get('.colorBtn').trigger('click')
+    await w.get('.box').trigger('keydown', { key: 'Escape' })
+    expect(w.get('.box').classes()).not.toContain('open')
+    expect(w.emitted('close')).toHaveLength(1)
+  })
+
+  it('点击组件外部关闭面板', async () => {
+    const outside = document.createElement('div')
+    document.body.appendChild(outside)
+    const w = mountPicker()
+    await w.get('.colorBtn').trigger('click')
+    outside.dispatchEvent(new Event('pointerdown', { bubbles: true }))
+    await nextTick()
+    expect(w.get('.box').classes()).not.toContain('open')
+  })
+
+  it('键盘 Enter 可切换面板', async () => {
+    const w = mountPicker()
+    await w.get('.colorBtn').trigger('keydown', { key: 'Enter' })
+    expect(w.get('.box').classes()).toContain('open')
+    await w.get('.colorBtn').trigger('keydown', { key: 'Enter' })
+    expect(w.get('.box').classes()).not.toContain('open')
+  })
+})
+
+describe('颜色选取', () => {
+  it('点击主题色 emit update:modelValue 与 change 并关闭面板', async () => {
+    const w = mountPicker()
+    await w.get('.colorBtn').trigger('click')
+    await w.get('[data-cell="0-0"]').trigger('click')
+    expect(w.emitted('update:modelValue')).toEqual([['#000000']])
+    expect(w.emitted('change')).toEqual([['#000000']])
+    expect(w.get('.box').classes()).not.toContain('open')
+  })
+
+  it('点击默认颜色恢复 defaultColor', async () => {
+    const w = mountPicker({ defaultColor: '#123456' })
+    await w.get('.colorBtn').trigger('click')
+    await w.get('.defaultColor').trigger('click')
+    expect(w.emitted('update:modelValue')).toEqual([['#123456']])
+  })
+
+  it('hover 色块 emit hover 事件', async () => {
+    const w = mountPicker()
+    await w.get('.colorBtn').trigger('click')
+    await w.get('[data-cell="0-1"]').trigger('mouseover')
+    expect(w.emitted('hover')?.[0]).toEqual(['#ffffff'])
+  })
+})
+
+describe('色块网格键盘导航', () => {
+  it('初始只有第一个色块可 Tab 进入（roving tabindex）', async () => {
+    const w = mountPicker()
+    await w.get('.colorBtn').trigger('click')
+    expect(w.get('[data-cell="0-0"]').attributes('tabindex')).toBe('0')
+    expect(w.get('[data-cell="0-1"]').attributes('tabindex')).toBe('-1')
+  })
+
+  it('ArrowRight 将漫游焦点移到下一格', async () => {
+    const w = mountPicker()
+    await w.get('.colorBtn').trigger('click')
+    await w.get('[data-cell="0-0"]').trigger('keydown', { key: 'ArrowRight' })
+    await nextTick()
+    expect(w.get('[data-cell="0-1"]').attributes('tabindex')).toBe('0')
+    expect(w.get('[data-cell="0-0"]').attributes('tabindex')).toBe('-1')
+    expect(document.activeElement).toBe(w.get('[data-cell="0-1"]').element)
+  })
+
+  it('ArrowDown 从主题色行进入渐变面板行', async () => {
+    const w = mountPicker()
+    await w.get('.colorBtn').trigger('click')
+    await w.get('[data-cell="0-0"]').trigger('keydown', { key: 'ArrowDown' })
+    await nextTick()
+    expect(w.get('[data-cell="1-0"]').attributes('tabindex')).toBe('0')
+  })
+
+  it('End 跳到行尾，边界不越界', async () => {
+    const w = mountPicker()
+    await w.get('.colorBtn').trigger('click')
+    await w.get('[data-cell="0-0"]').trigger('keydown', { key: 'End' })
+    await nextTick()
+    expect(w.get('[data-cell="0-9"]').attributes('tabindex')).toBe('0')
+    await w.get('[data-cell="0-9"]').trigger('keydown', { key: 'ArrowRight' })
+    await nextTick()
+    expect(w.get('[data-cell="0-9"]').attributes('tabindex')).toBe('0')
+  })
+
+  it('Enter 选中当前色块', async () => {
+    const w = mountPicker()
+    await w.get('.colorBtn').trigger('click')
+    await w.get('[data-cell="0-0"]').trigger('keydown', { key: 'ArrowRight' })
+    await nextTick()
+    await w.get('[data-cell="0-1"]').trigger('keydown', { key: 'Enter' })
+    expect(w.emitted('update:modelValue')).toEqual([['#ffffff']])
+  })
+})
+
+describe('teleport', () => {
+  it('teleport: true 时面板渲染到 body 下', async () => {
+    const w = mountPicker({ teleport: true })
+    // 面板不在组件根元素内部
+    expect(w.element.querySelector('.m-colorPicker-box')).toBeNull()
+    const panel = document.body.querySelector('.m-colorPicker-box')
+    expect(panel).not.toBeNull()
+    expect(panel!.parentElement).toBe(document.body)
+    await w.get('.colorBtn').trigger('click')
+    await nextTick()
+    expect(panel!.classList.contains('open')).toBe(true)
+    // fixed 定位由内联样式接管
+    expect((panel as HTMLElement).style.position).toBe('fixed')
+  })
+
+  it('teleport 面板内点击不会被误判为外部点击', async () => {
+    const w = mountPicker({ teleport: true })
+    await w.get('.colorBtn').trigger('click')
+    const panel = document.body.querySelector('.m-colorPicker-box') as HTMLElement
+    panel.dispatchEvent(new Event('pointerdown', { bubbles: true }))
+    await nextTick()
+    expect(panel.classList.contains('open')).toBe(true)
+  })
+})

--- a/packages/color-picker/__tests__/utils.spec.ts
+++ b/packages/color-picker/__tests__/utils.spec.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+import {
+  COLOR_PANEL,
+  GRADIENT_STEPS,
+  STANDARD_COLORS,
+  THEME_COLORS,
+  clamp,
+  gradient,
+  hexToRgb,
+  normalizeLocale,
+  parseColor,
+  parsePlacement,
+  rgbToHex
+} from '../src/utils'
+
+describe('parseColor', () => {
+  it('接受标准 6 位 hex', () => {
+    expect(parseColor('#1e497b')).toBe('#1e497b')
+  })
+
+  it('大写与空白被规范化', () => {
+    expect(parseColor('  #FF00AA ')).toBe('#ff00aa')
+  })
+
+  it('展开 3 位缩写', () => {
+    expect(parseColor('#abc')).toBe('#aabbcc')
+  })
+
+  it('自动补全缺失的 # 前缀', () => {
+    expect(parseColor('ff0000')).toBe('#ff0000')
+  })
+
+  it('非法输入回退到黑色', () => {
+    expect(parseColor('')).toBe('#000000')
+    expect(parseColor('not-a-color')).toBe('#000000')
+    expect(parseColor('#12345')).toBe('#000000')
+    expect(parseColor('#gggggg')).toBe('#000000')
+  })
+})
+
+describe('hexToRgb / rgbToHex', () => {
+  it('互为往返', () => {
+    expect(rgbToHex(...hexToRgb('#4e81bb'))).toBe('#4e81bb')
+  })
+
+  it('rgbToHex 对越界分量做钳制', () => {
+    expect(rgbToHex(-10, 300, 128)).toBe('#00ff80')
+  })
+})
+
+describe('clamp', () => {
+  it('限制在区间内', () => {
+    expect(clamp(5, 0, 10)).toBe(5)
+    expect(clamp(-1, 0, 10)).toBe(0)
+    expect(clamp(11, 0, 10)).toBe(10)
+  })
+})
+
+describe('gradient', () => {
+  it('生成指定步数并以起点开头', () => {
+    const out = gradient('#000000', '#ffffff', 5)
+    expect(out).toHaveLength(5)
+    expect(out[0]).toBe('#000000')
+  })
+
+  it('单调渐变到接近终点', () => {
+    const out = gradient('#000000', '#ffffff', 5)
+    const [r] = hexToRgb(out[4])
+    expect(r).toBeGreaterThan(150)
+  })
+})
+
+describe('COLOR_PANEL 预计算', () => {
+  it('10 列，每列 GRADIENT_STEPS 行', () => {
+    expect(COLOR_PANEL).toHaveLength(10)
+    for (const col of COLOR_PANEL) expect(col).toHaveLength(GRADIENT_STEPS)
+  })
+
+  it('全部为合法 hex', () => {
+    for (const col of COLOR_PANEL) {
+      for (const color of col) expect(color).toMatch(/^#[0-9a-f]{6}$/)
+    }
+  })
+})
+
+describe('normalizeLocale', () => {
+  it('空值回退 zh-CN', () => {
+    expect(normalizeLocale()).toBe('zh-CN')
+    expect(normalizeLocale('')).toBe('zh-CN')
+  })
+
+  it('按前缀匹配', () => {
+    expect(normalizeLocale('zh-TW')).toBe('zh-CN')
+    expect(normalizeLocale('ja')).toBe('ja-JP')
+    expect(normalizeLocale('en-GB')).toBe('en-US')
+    expect(normalizeLocale('fr-FR')).toBe('en-US')
+  })
+})
+
+describe('parsePlacement', () => {
+  it('auto 时两轴均为 auto', () => {
+    expect(parsePlacement('auto')).toEqual({ vertical: 'auto', horizontal: 'auto' })
+  })
+
+  it('只给垂直方向时水平为 auto', () => {
+    expect(parsePlacement('top')).toEqual({ vertical: 'top', horizontal: 'auto' })
+  })
+
+  it('start/end 映射为 left/right', () => {
+    expect(parsePlacement('bottom-start')).toEqual({ vertical: 'bottom', horizontal: 'left' })
+    expect(parsePlacement('top-end')).toEqual({ vertical: 'top', horizontal: 'right' })
+  })
+})
+
+describe('色板常量', () => {
+  it('主题色与标准色各 10 个', () => {
+    expect(THEME_COLORS).toHaveLength(10)
+    expect(STANDARD_COLORS).toHaveLength(10)
+  })
+})

--- a/packages/color-picker/src/index.vue
+++ b/packages/color-picker/src/index.vue
@@ -1,175 +1,24 @@
 <script lang="ts">
-// 声明无法在 <script setup> 中声明的选项；本块为模块作用域，常量只初始化一次
-import type {
-  ColorPickerExposed,
-  ColorPickerLocale,
-  ColorPickerMessages,
-  ColorPickerPlacement
-} from './types'
-
+// 声明无法在 <script setup> 中声明的选项
 export default {
   name: "colorPicker"
-}
-
-type ResolvedPlacement = {
-  vertical: 'top' | 'bottom' | 'auto'
-  horizontal: 'left' | 'right' | 'auto'
-}
-
-const parsePlacement = (p: ColorPickerPlacement): ResolvedPlacement => {
-  if (p === 'auto') return { vertical: 'auto', horizontal: 'auto' }
-  const [v, h] = p.split('-') as ['top' | 'bottom', 'start' | 'end' | undefined]
-  return {
-    vertical: v,
-    horizontal: h ? (h === 'start' ? 'left' : 'right') : 'auto'
-  }
-}
-
-const localeMessagesMap: Record<ColorPickerLocale, ColorPickerMessages> = {
-  'zh-CN': {
-    defaultColor: '默认颜色',
-    themeColors: '主题颜色',
-    standardColors: '标准颜色',
-    moreColors: '更多颜色...',
-    pickerLabel: '颜色选择器'
-  },
-  'en-US': {
-    defaultColor: 'Default',
-    themeColors: 'Theme Colors',
-    standardColors: 'Standard Colors',
-    moreColors: 'More Colors...',
-    pickerLabel: 'Color picker'
-  },
-  'ja-JP': {
-    defaultColor: 'デフォルトカラー',
-    themeColors: 'テーマカラー',
-    standardColors: '標準カラー',
-    moreColors: 'その他のカラー...',
-    pickerLabel: 'カラーピッカー'
-  }
-}
-
-// 主题颜色
-const THEME_COLORS = [
-  '#000000', '#ffffff', '#eeece1', '#1e497b', '#4e81bb',
-  '#e2534d', '#9aba60', '#8165a0', '#47acc5', '#f9974c'
-] as const
-
-// 标准颜色
-const STANDARD_COLORS = [
-  '#c21401', '#ff1e02', '#ffc12a', '#ffff3a', '#90cf5b',
-  '#00af57', '#00afee', '#0071be', '#00215f', '#72349d'
-] as const
-
-// 色板渐变源 [深色, 浅色]
-const COLOR_CONFIG: ReadonlyArray<readonly [string, string]> = [
-  ['#7f7f7f', '#f2f2f2'],
-  ['#0d0d0d', '#808080'],
-  ['#1c1a10', '#ddd8c3'],
-  ['#0e243d', '#c6d9f0'],
-  ['#233f5e', '#dae5f0'],
-  ['#632623', '#f2dbdb'],
-  ['#4d602c', '#eaf1de'],
-  ['#3f3150', '#e6e0ec'],
-  ['#1e5867', '#d9eef3'],
-  ['#99490f', '#fee9da']
-]
-
-const GRADIENT_STEPS = 5
-
-const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v))
-
-// 规范化 hex 字符串；非法输入回退到黑色
-const parseColor = (input: string): string => {
-  if (!input || typeof input !== 'string') return '#000000'
-  let hex = input.trim().toLowerCase()
-  if (!hex.startsWith('#')) hex = '#' + hex
-  if (/^#[0-9a-f]{3}$/.test(hex)) {
-    return '#' + hex[1] + hex[1] + hex[2] + hex[2] + hex[3] + hex[3]
-  }
-  if (/^#[0-9a-f]{6}$/.test(hex)) return hex
-  return '#000000'
-}
-
-const hexToRgb = (hex: string): [number, number, number] => {
-  const h = parseColor(hex)
-  return [
-    parseInt(h.slice(1, 3), 16),
-    parseInt(h.slice(3, 5), 16),
-    parseInt(h.slice(5, 7), 16)
-  ]
-}
-
-const rgbToHex = (r: number, g: number, b: number): string => {
-  const toComp = (n: number) => clamp(Math.round(n), 0, 255).toString(16).padStart(2, '0')
-  return '#' + toComp(r) + toComp(g) + toComp(b)
-}
-
-const gradient = (start: string, end: string, step: number): string[] => {
-  const [sr, sg, sb] = hexToRgb(start)
-  const [er, eg, eb] = hexToRgb(end)
-  const rStep = (er - sr) / step
-  const gStep = (eg - sg) / step
-  const bStep = (eb - sb) / step
-  const out: string[] = []
-  for (let i = 0; i < step; i++) {
-    out.push(rgbToHex(sr + rStep * i, sg + gStep * i, sb + bStep * i))
-  }
-  return out
-}
-
-// 预计算一次的渐变面板：浅 -> 深
-const COLOR_PANEL: ReadonlyArray<ReadonlyArray<string>> = COLOR_CONFIG.map(
-  ([dark, light]) => gradient(light, dark, GRADIENT_STEPS)
-)
-
-const normalizeLocale = (locale?: string): ColorPickerLocale => {
-  if (!locale) return 'zh-CN'
-  const l = locale.toLowerCase()
-  if (l.startsWith('zh')) return 'zh-CN'
-  if (l.startsWith('ja')) return 'ja-JP'
-  return 'en-US'
-}
-
-const detectLocale = (): ColorPickerLocale => {
-  if (typeof document !== 'undefined') {
-    const lang = document.documentElement.lang
-    if (lang) return normalizeLocale(lang)
-  }
-  if (typeof navigator !== 'undefined') return normalizeLocale(navigator.language)
-  return 'zh-CN'
-}
-
-// MutationObserver 单例：所有组件实例共享一个 observer，引用计数为 0 时断开
-type LangListener = (locale: ColorPickerLocale) => void
-const langListeners = new Set<LangListener>()
-let sharedLangObserver: MutationObserver | null = null
-
-const subscribeLang = (cb: LangListener): (() => void) => {
-  langListeners.add(cb)
-  if (typeof document !== 'undefined' && !sharedLangObserver) {
-    sharedLangObserver = new MutationObserver(() => {
-      const next = detectLocale()
-      langListeners.forEach(fn => fn(next))
-    })
-    sharedLangObserver.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ['lang']
-    })
-  }
-  return () => {
-    langListeners.delete(cb)
-    if (langListeners.size === 0 && sharedLangObserver) {
-      sharedLangObserver.disconnect()
-      sharedLangObserver = null
-    }
-  }
 }
 </script>
 
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, shallowRef, useTemplateRef } from 'vue'
-import { onClickOutside } from '@vueuse/core'
+import type { ColorPickerLocale, ColorPickerMessages, ColorPickerPlacement, ColorPickerExposed } from './types'
+import {
+  COLOR_PANEL,
+  GRADIENT_STEPS,
+  STANDARD_COLORS,
+  THEME_COLORS,
+  detectLocale,
+  localeMessagesMap,
+  normalizeLocale,
+  parsePlacement,
+  subscribeLang
+} from './utils'
 
 const props = withDefaults(defineProps<{
   // 当前颜色
@@ -184,10 +33,13 @@ const props = withDefaults(defineProps<{
   messages?: Partial<ColorPickerMessages>
   // 面板位置；默认 'auto' 由视口空间决定
   placement?: ColorPickerPlacement
+  // 将面板渲染到指定容器（true = body），避免被 overflow: hidden 祖先裁剪
+  teleport?: boolean | string
 }>(), {
   defaultColor: '#000000',
   messages: () => ({}),
-  placement: 'auto'
+  placement: 'auto',
+  teleport: false
 })
 
 const emits = defineEmits<{
@@ -221,11 +73,41 @@ const resolvedMessages = computed<ColorPickerMessages>(() => ({
 
 const showColor = computed(() => props.modelValue || props.defaultColor)
 const showPanelColor = computed(() => hoverColor.value || showColor.value)
+// aria-selected 用：大小写 / 空白不敏感地和色块 hex 比较
+const normalizedShowColor = computed(() => showColor.value.trim().toLowerCase())
+
+const isTeleported = computed(() => !!props.teleport)
+const teleportTarget = computed(() =>
+  typeof props.teleport === 'string' && props.teleport ? props.teleport : 'body'
+)
 
 const colorPicker = useTemplateRef<HTMLDivElement>('colorPicker')
 const colorPanelEl = useTemplateRef<HTMLDivElement>('colorPanelEl')
 const triggerEl = useTemplateRef<HTMLDivElement>('triggerEl')
 const html5ColorEl = useTemplateRef<HTMLInputElement>('html5ColorEl')
+
+// teleport 时面板脱离触发器的定位上下文，改用 fixed + 像素坐标
+const panelStyle = shallowRef<Record<string, string>>({})
+
+const computeTeleportStyle = () => {
+  if (!isTeleported.value || !colorPicker.value) return
+  const triggerRect = colorPicker.value.getBoundingClientRect()
+  const panelRect = colorPanelEl.value?.getBoundingClientRect()
+  const gap = 2
+  const top = panelVerticalPlacement.value === 'top' && panelRect
+    ? triggerRect.top - panelRect.height - gap
+    : triggerRect.bottom + gap
+  const left = panelHorizontalPlacement.value === 'right' && panelRect
+    ? triggerRect.right - panelRect.width
+    : triggerRect.left
+  panelStyle.value = {
+    position: 'fixed',
+    top: `${top}px`,
+    left: `${left}px`,
+    right: 'auto',
+    bottom: 'auto'
+  }
+}
 
 // rAF 合并的 placement 更新
 let placementRaf = 0
@@ -242,30 +124,31 @@ const updatePanelPlacement = () => {
 
   const placement = parsePlacement(props.placement)
 
-  // 用户显式锁定的方向直接采用，无需测量
-  if (placement.vertical !== 'auto' && placement.horizontal !== 'auto') {
+  if (placement.vertical === 'auto' || placement.horizontal === 'auto') {
+    const triggerRect = colorPicker.value.getBoundingClientRect()
+    const panelRect = colorPanelEl.value.getBoundingClientRect()
+    const viewportHeight = window.innerHeight
+    const viewportWidth = window.innerWidth
+
+    const spaceBelow = viewportHeight - triggerRect.bottom
+    const spaceAbove = triggerRect.top
+    const spaceRight = viewportWidth - triggerRect.left
+    const leftAvailableSpace = triggerRect.right
+
+    panelVerticalPlacement.value = placement.vertical !== 'auto'
+      ? placement.vertical
+      : (panelRect.height > spaceBelow && spaceAbove > spaceBelow ? 'top' : 'bottom')
+
+    panelHorizontalPlacement.value = placement.horizontal !== 'auto'
+      ? placement.horizontal
+      : (panelRect.width > spaceRight && leftAvailableSpace > spaceRight ? 'right' : 'left')
+  } else {
+    // 用户显式锁定的方向直接采用，无需测量
     panelVerticalPlacement.value = placement.vertical
     panelHorizontalPlacement.value = placement.horizontal
-    return
   }
 
-  const triggerRect = colorPicker.value.getBoundingClientRect()
-  const panelRect = colorPanelEl.value.getBoundingClientRect()
-  const viewportHeight = window.innerHeight
-  const viewportWidth = window.innerWidth
-
-  const spaceBelow = viewportHeight - triggerRect.bottom
-  const spaceAbove = triggerRect.top
-  const spaceRight = viewportWidth - triggerRect.left
-  const leftAvailableSpace = triggerRect.right
-
-  panelVerticalPlacement.value = placement.vertical !== 'auto'
-    ? placement.vertical
-    : (panelRect.height > spaceBelow && spaceAbove > spaceBelow ? 'top' : 'bottom')
-
-  panelHorizontalPlacement.value = placement.horizontal !== 'auto'
-    ? placement.horizontal
-    : (panelRect.width > spaceRight && leftAvailableSpace > spaceRight ? 'right' : 'left')
+  computeTeleportStyle()
 }
 
 const attachViewportListeners = () => {
@@ -282,19 +165,34 @@ const detachViewportListeners = () => {
   }
 }
 
+// 点击组件外部（触发器和面板都不包含目标）时关闭；仅在面板打开期间监听
+const onDocumentPointerDown = (event: Event) => {
+  const target = event.target as Node | null
+  if (!target) return
+  if (colorPicker.value?.contains(target)) return
+  if (colorPanelEl.value?.contains(target)) return
+  closePanel()
+}
+
 const openPanel = () => {
   if (props.disabled || openStatus.value) return
   // 同步先把用户锁定的方向写入，避免首帧 bottom-left → 目标位置闪烁
   const p = parsePlacement(props.placement)
   if (p.vertical !== 'auto') panelVerticalPlacement.value = p.vertical
   if (p.horizontal !== 'auto') panelHorizontalPlacement.value = p.horizontal
+  // 键盘漫游焦点回到第一个色块
+  activeRow.value = 0
+  activeCol.value = 0
+  // 先用触发器位置放一版，nextTick 量出面板尺寸后校准
+  if (isTeleported.value) computeTeleportStyle()
   openStatus.value = true
-  // 完全锁定时视口变化不影响位置，无需挂 viewport listeners
-  const needsAutoMeasure = p.vertical === 'auto' || p.horizontal === 'auto'
-  if (needsAutoMeasure) {
+  // teleport 的 fixed 定位需要持续跟随视口；行内渲染只有 auto 方向才需要测量
+  const needsViewportTracking = isTeleported.value || p.vertical === 'auto' || p.horizontal === 'auto'
+  if (needsViewportTracking) {
     attachViewportListeners()
     void nextTick(updatePanelPlacement)
   }
+  document.addEventListener('pointerdown', onDocumentPointerDown, true)
   emits('open')
 }
 
@@ -302,6 +200,7 @@ const closePanel = () => {
   if (!openStatus.value) return
   openStatus.value = false
   detachViewportListeners()
+  document.removeEventListener('pointerdown', onDocumentPointerDown, true)
   emits('close')
 }
 
@@ -310,8 +209,6 @@ const togglePanel = () => {
   if (openStatus.value) closePanel()
   else openPanel()
 }
-
-onClickOutside(colorPicker, closePanel)
 
 const focusTrigger = () => {
   void nextTick(() => triggerEl.value?.focus())
@@ -335,6 +232,67 @@ const handleHtml5ColorChange = (event: Event) => {
   updateValue((event.target as HTMLInputElement).value)
 }
 
+// ---- 色块网格键盘导航（roving tabindex）----
+// 逻辑网格：第 0 行主题色，第 1..GRADIENT_STEPS 行渐变面板，最后一行标准色
+const GRID_ROWS = GRADIENT_STEPS + 2
+const GRID_COLS = THEME_COLORS.length
+
+const activeRow = shallowRef(0)
+const activeCol = shallowRef(0)
+
+const colorAt = (row: number, col: number): string => {
+  if (row === 0) return THEME_COLORS[col]
+  if (row === GRID_ROWS - 1) return STANDARD_COLORS[col]
+  return COLOR_PANEL[col][row - 1]
+}
+
+const cellTabindex = (row: number, col: number) =>
+  activeRow.value === row && activeCol.value === col ? 0 : -1
+
+const focusCell = (row: number, col: number) => {
+  activeRow.value = row
+  activeCol.value = col
+  void nextTick(() => {
+    colorPanelEl.value
+      ?.querySelector<HTMLElement>(`[data-cell="${row}-${col}"]`)
+      ?.focus()
+  })
+}
+
+const onSwatchKeydown = (e: KeyboardEvent, row: number, col: number) => {
+  switch (e.key) {
+    case 'Enter':
+    case ' ':
+      e.preventDefault()
+      updateValue(colorAt(row, col))
+      return
+    case 'ArrowRight':
+      e.preventDefault()
+      focusCell(row, Math.min(col + 1, GRID_COLS - 1))
+      return
+    case 'ArrowLeft':
+      e.preventDefault()
+      focusCell(row, Math.max(col - 1, 0))
+      return
+    case 'ArrowDown':
+      e.preventDefault()
+      focusCell(Math.min(row + 1, GRID_ROWS - 1), col)
+      return
+    case 'ArrowUp':
+      e.preventDefault()
+      focusCell(Math.max(row - 1, 0), col)
+      return
+    case 'Home':
+      e.preventDefault()
+      focusCell(row, 0)
+      return
+    case 'End':
+      e.preventDefault()
+      focusCell(row, GRID_COLS - 1)
+      return
+  }
+}
+
 // 键盘交互
 const onTriggerKeydown = (e: KeyboardEvent) => {
   if (props.disabled) return
@@ -347,6 +305,7 @@ const onTriggerKeydown = (e: KeyboardEvent) => {
   } else if ((e.key === 'ArrowDown' || e.key === 'ArrowUp') && !openStatus.value) {
     e.preventDefault()
     openPanel()
+    focusCell(0, 0)
   }
 }
 
@@ -378,6 +337,7 @@ onBeforeUnmount(() => {
   unsubscribeLang?.()
   unsubscribeLang = null
   detachViewportListeners()
+  document.removeEventListener('pointerdown', onDocumentPointerDown, true)
 })
 
 defineExpose<ColorPickerExposed>({
@@ -404,171 +364,195 @@ defineExpose<ColorPickerExposed>({
       @click="togglePanel"
       @keydown="onTriggerKeydown"
     ></div>
-    <!-- 颜色色盘 -->
-    <div
-      ref="colorPanelEl"
-      class="box"
-      role="dialog"
-      aria-modal="false"
-      :aria-hidden="!openStatus"
-      :aria-label="resolvedMessages.pickerLabel"
-      :class="{
-        open: openStatus,
-        'placement-top': panelVerticalPlacement === 'top',
-        'placement-right': panelHorizontalPlacement === 'right'
-      }"
-      @keydown="onPanelKeydown"
-    >
-      <div class="hd">
-        <div class="colorView" :style="{ backgroundColor: showPanelColor }"></div>
-        <div
-          class="defaultColor"
-          role="button"
-          tabindex="0"
-          @click="handleDefaultColor"
-          @keydown="(e) => onActivate(e, handleDefaultColor)"
-          @mouseover="handleHover(defaultColor)"
-          @mouseout="handleHover('')"
-        >{{ resolvedMessages.defaultColor }}</div>
-      </div>
-      <div class="bd">
-        <h3>{{ resolvedMessages.themeColors }}</h3>
-        <ul class="tColor" role="grid">
-          <li
-            v-for="(color, index) of THEME_COLORS"
-            :key="index"
-            role="gridcell"
+    <!-- 颜色色盘；teleport 开启时渲染到目标容器，避免被祖先 overflow 裁剪 -->
+    <Teleport :to="teleportTarget" :disabled="!isTeleported">
+      <div
+        ref="colorPanelEl"
+        class="box m-colorPicker-box"
+        role="dialog"
+        aria-modal="false"
+        :aria-hidden="!openStatus"
+        :aria-label="resolvedMessages.pickerLabel"
+        :class="{
+          open: openStatus,
+          'placement-top': panelVerticalPlacement === 'top',
+          'placement-right': panelHorizontalPlacement === 'right'
+        }"
+        :style="isTeleported ? panelStyle : undefined"
+        @keydown="onPanelKeydown"
+      >
+        <div class="hd">
+          <div class="colorView" :style="{ backgroundColor: showPanelColor }"></div>
+          <div
+            class="defaultColor"
+            role="button"
             tabindex="0"
-            :aria-label="color"
-            :style="{ backgroundColor: color }"
-            @mouseover="handleHover(color)"
+            @click="handleDefaultColor"
+            @keydown="(e) => onActivate(e, handleDefaultColor)"
+            @mouseover="handleHover(defaultColor)"
             @mouseout="handleHover('')"
-            @click="updateValue(color)"
-            @keydown="(e) => onActivate(e, () => updateValue(color))"
-          ></li>
-        </ul>
-        <ul class="bColor" role="grid">
-          <li v-for="(item, index) of COLOR_PANEL" :key="index" role="row">
-            <ul>
-              <li
-                v-for="(color, cindex) of item"
-                :key="cindex"
-                role="gridcell"
-                tabindex="0"
-                :aria-label="color"
-                :style="{ backgroundColor: color }"
-                @mouseover="handleHover(color)"
-                @mouseout="handleHover('')"
-                @click="updateValue(color)"
-                @keydown="(e) => onActivate(e, () => updateValue(color))"
-              ></li>
-            </ul>
-          </li>
-        </ul>
-        <h3>{{ resolvedMessages.standardColors }}</h3>
-        <ul class="tColor" role="grid">
-          <li
-            v-for="(color, index) of STANDARD_COLORS"
-            :key="index"
-            role="gridcell"
+          >{{ resolvedMessages.defaultColor }}</div>
+        </div>
+        <div class="bd">
+          <h3>{{ resolvedMessages.themeColors }}</h3>
+          <ul
+            class="tColor"
+            role="listbox"
+            aria-orientation="horizontal"
+            :aria-label="resolvedMessages.themeColors"
+          >
+            <li
+              v-for="(color, index) of THEME_COLORS"
+              :key="color"
+              role="option"
+              :aria-selected="color === normalizedShowColor"
+              :tabindex="cellTabindex(0, index)"
+              :data-cell="`0-${index}`"
+              :aria-label="color"
+              :style="{ backgroundColor: color }"
+              @mouseover="handleHover(color)"
+              @mouseout="handleHover('')"
+              @click="updateValue(color)"
+              @keydown="(e) => onSwatchKeydown(e, 0, index)"
+            ></li>
+          </ul>
+          <ul class="bColor" role="grid" :aria-label="resolvedMessages.themeColors">
+            <li v-for="(item, cIndex) of COLOR_PANEL" :key="cIndex" role="row">
+              <ul role="presentation">
+                <li
+                  v-for="(color, rIndex) of item"
+                  :key="color"
+                  role="gridcell"
+                  :tabindex="cellTabindex(rIndex + 1, cIndex)"
+                  :data-cell="`${rIndex + 1}-${cIndex}`"
+                  :aria-label="color"
+                  :style="{ backgroundColor: color }"
+                  @mouseover="handleHover(color)"
+                  @mouseout="handleHover('')"
+                  @click="updateValue(color)"
+                  @keydown="(e) => onSwatchKeydown(e, rIndex + 1, cIndex)"
+                ></li>
+              </ul>
+            </li>
+          </ul>
+          <h3>{{ resolvedMessages.standardColors }}</h3>
+          <ul
+            class="tColor"
+            role="listbox"
+            aria-orientation="horizontal"
+            :aria-label="resolvedMessages.standardColors"
+          >
+            <li
+              v-for="(color, index) of STANDARD_COLORS"
+              :key="color"
+              role="option"
+              :aria-selected="color === normalizedShowColor"
+              :tabindex="cellTabindex(GRID_ROWS - 1, index)"
+              :data-cell="`${GRID_ROWS - 1}-${index}`"
+              :aria-label="color"
+              :style="{ backgroundColor: color }"
+              @mouseover="handleHover(color)"
+              @mouseout="handleHover('')"
+              @click="updateValue(color)"
+              @keydown="(e) => onSwatchKeydown(e, GRID_ROWS - 1, index)"
+            ></li>
+          </ul>
+          <h3
+            class="moreColors"
+            role="button"
             tabindex="0"
-            :aria-label="color"
-            :style="{ backgroundColor: color }"
-            @mouseover="handleHover(color)"
-            @mouseout="handleHover('')"
-            @click="updateValue(color)"
-            @keydown="(e) => onActivate(e, () => updateValue(color))"
-          ></li>
-        </ul>
-        <h3
-          class="moreColors"
-          role="button"
-          tabindex="0"
-          @click="triggerHtml5Color"
-          @keydown="(e) => onActivate(e, triggerHtml5Color)"
-        >{{ resolvedMessages.moreColors }}</h3>
-        <!--
-          用以激活 HTML5 原生颜色面板。
-          监听 @change（用户在原生面板里点确定）而非 @input（拖动持续触发），
-          避免拖动时反复 emit + focusTrigger 抢焦点。
-        -->
-        <input
-          type="color"
-          ref="html5ColorEl"
-          aria-hidden="true"
-          tabindex="-1"
-          :value="showColor"
-          @change="handleHtml5ColorChange"
-        >
+            @click="triggerHtml5Color"
+            @keydown="(e) => onActivate(e, triggerHtml5Color)"
+          >{{ resolvedMessages.moreColors }}</h3>
+          <!--
+            用以激活 HTML5 原生颜色面板。
+            监听 @change（用户在原生面板里点确定）而非 @input（拖动持续触发），
+            避免拖动时反复 emit + focusTrigger 抢焦点。
+          -->
+          <input
+            type="color"
+            ref="html5ColorEl"
+            aria-hidden="true"
+            tabindex="-1"
+            :value="showColor"
+            @change="handleHtml5ColorChange"
+          >
+        </div>
       </div>
-    </div>
+    </Teleport>
   </div>
 </template>
 
 <style lang="scss">
-.m-colorPicker{
-  // CSS Variables - 可被外部覆盖以定制主题
-  --vcp-swatch-size: 15px;
-  --vcp-panel-width: 190px;
-  --vcp-panel-bg: #fff;
-  --vcp-panel-border: 1px solid #ddd;
-  --vcp-panel-radius: 2px;
-  --vcp-panel-shadow: 0 8px 24px rgba(0, 0, 0, .18);
-  --vcp-panel-padding: 10px;
-  --vcp-text-color: #333;
-  --vcp-focus-color: #4e81bb;
-  --vcp-transition: .3s ease;
-  --vcp-z-index: 10000;
+// CSS Variables 主题化：组件自身不声明变量，所有使用点带默认值回退。
+// 自定义属性「元素自身声明优先于继承」，若在面板元素上声明默认值，
+// 用户在 :root / .m-colorPicker 等祖先上的覆盖将永远传不进面板。
+// 用回退值则任意层级（:root、.m-colorPicker、.m-colorPicker-box）覆盖均生效。
+$swatch-size: var(--vcp-swatch-size, 15px);
+$panel-width: var(--vcp-panel-width, 190px);
+$panel-bg: var(--vcp-panel-bg, #fff);
+$panel-border: var(--vcp-panel-border, 1px solid #ddd);
+$panel-radius: var(--vcp-panel-radius, 2px);
+$panel-shadow: var(--vcp-panel-shadow, 0 8px 24px rgba(0, 0, 0, .18));
+$panel-padding: var(--vcp-panel-padding, 10px);
+$text-color: var(--vcp-text-color, #333);
+$focus-color: var(--vcp-focus-color, #4e81bb);
+$transition: var(--vcp-transition, .3s ease);
+$z-index: var(--vcp-z-index, 10000);
 
+.m-colorPicker{
   position: relative; text-align: left; font-size: 14px; display: inline-block;
   outline: none;
-  ul,li,ol{ list-style: none; margin: 0; padding: 0; }
-  .colorBtn{ width: var(--vcp-swatch-size); height: var(--vcp-swatch-size); cursor: pointer; }
+  .colorBtn{ width: $swatch-size; height: $swatch-size; cursor: pointer; }
   .colorBtn.disabled{ cursor: no-drop; }
-  .colorBtn:focus-visible{ outline: 2px solid var(--vcp-focus-color); outline-offset: 2px; }
-  &.open{ z-index: var(--vcp-z-index); }
-  .box{
-    position: absolute; top: calc(100% + 2px); left: 0;
-    width: var(--vcp-panel-width);
-    background: var(--vcp-panel-bg);
-    border: var(--vcp-panel-border);
-    border-radius: var(--vcp-panel-radius);
-    box-shadow: var(--vcp-panel-shadow);
-    padding: var(--vcp-panel-padding); padding-bottom: 5px;
-    visibility: hidden; margin-top: 0; opacity: 0; transition: all var(--vcp-transition);
-    box-sizing: content-box;
-    z-index: 1;
-    pointer-events: none;
-    h3{ margin: 0; font-size: 14px; font-weight: normal; margin-top: 10px; margin-bottom: 5px; line-height: 1; color: var(--vcp-text-color); }
-    h3.moreColors{ cursor: pointer; }
-    h3.moreColors:focus-visible{ outline: 1px dashed var(--vcp-focus-color); outline-offset: 2px; }
-    input {
-      visibility: hidden;
-      position: absolute;
-      left: 0;
-      bottom: 0;
-    }
+  .colorBtn:focus-visible{ outline: 2px solid $focus-color; outline-offset: 2px; }
+  &.open{ z-index: $z-index; }
+}
+
+// 面板样式独立成顶层类：teleport 时面板脱离 .m-colorPicker 渲染
+.m-colorPicker-box{
+  position: absolute; top: calc(100% + 2px); left: 0;
+  width: $panel-width;
+  text-align: left; font-size: 14px;
+  background: $panel-bg;
+  border: $panel-border;
+  border-radius: $panel-radius;
+  box-shadow: $panel-shadow;
+  padding: $panel-padding; padding-bottom: 5px;
+  visibility: hidden; margin-top: 0; opacity: 0; transition: all $transition;
+  box-sizing: content-box;
+  z-index: 1;
+  pointer-events: none;
+  ul,li,ol{ list-style: none; margin: 0; padding: 0; }
+  h3{ margin: 0; font-size: 14px; font-weight: normal; margin-top: 10px; margin-bottom: 5px; line-height: 1; color: $text-color; }
+  h3.moreColors{ cursor: pointer; }
+  h3.moreColors:focus-visible{ outline: 1px dashed $focus-color; outline-offset: 2px; }
+  input {
+    visibility: hidden;
+    position: absolute;
+    left: 0;
+    bottom: 0;
   }
-  .box.placement-top{ top: auto; bottom: calc(100% + 2px); }
-  .box.placement-right{ left: auto; right: 0; }
-  .box.open{ visibility: visible; opacity: 1; pointer-events: auto; }
+  &.placement-top{ top: auto; bottom: calc(100% + 2px); }
+  &.placement-right{ left: auto; right: 0; }
+  &.open{ visibility: visible; opacity: 1; pointer-events: auto; z-index: $z-index; }
   .hd{
     overflow: hidden; line-height: 29px;
-    .colorView{ width: 100px; height: 30px; float: left; transition: background-color var(--vcp-transition); }
-    .defaultColor{ width: 80px; float: right; text-align: center; border: var(--vcp-panel-border); cursor: pointer; color: var(--vcp-text-color); box-sizing: border-box; }
-    .defaultColor:focus-visible{ outline: 2px solid var(--vcp-focus-color); outline-offset: 1px; }
+    .colorView{ width: 100px; height: 30px; float: left; transition: background-color $transition; }
+    .defaultColor{ width: 80px; float: right; text-align: center; border: $panel-border; cursor: pointer; color: $text-color; box-sizing: border-box; }
+    .defaultColor:focus-visible{ outline: 2px solid $focus-color; outline-offset: 1px; }
   }
   .tColor{
-    li{ width: var(--vcp-swatch-size); height: var(--vcp-swatch-size); display: inline-block; margin: 0 2px; transition: all var(--vcp-transition); cursor: pointer; }
+    li{ width: $swatch-size; height: $swatch-size; display: inline-block; margin: 0 2px; transition: all $transition; cursor: pointer; }
     li:hover{ box-shadow: 0 0 5px rgba(0,0,0,.4); transform: scale(1.3); }
-    li:focus-visible{ outline: none; box-shadow: 0 0 0 2px var(--vcp-focus-color); position: relative; z-index: 1; }
+    li:focus-visible{ outline: none; box-shadow: 0 0 0 2px $focus-color; position: relative; z-index: 1; }
   }
   .bColor{
     li{
-      width: var(--vcp-swatch-size); display: inline-block; margin: 0 2px;
-      li{ display: block; width: var(--vcp-swatch-size); height: var(--vcp-swatch-size); transition: all var(--vcp-transition); margin: 0; cursor: pointer; }
+      width: $swatch-size; display: inline-block; margin: 0 2px;
+      li{ display: block; width: $swatch-size; height: $swatch-size; transition: all $transition; margin: 0; cursor: pointer; }
       li:hover{ box-shadow: 0 0 5px rgba(0,0,0,.4); transform: scale(1.3); }
-      li:focus-visible{ outline: none; box-shadow: 0 0 0 2px var(--vcp-focus-color); position: relative; z-index: 1; }
+      li:focus-visible{ outline: none; box-shadow: 0 0 0 2px $focus-color; position: relative; z-index: 1; }
     }
   }
 }

--- a/packages/color-picker/src/types.ts
+++ b/packages/color-picker/src/types.ts
@@ -1,31 +1,14 @@
 /**
- * Canonical type definitions for vcolorpicker.
+ * Type definitions used by the component source.
  *
- * NOTE: index.d.ts at the repo root re-declares the same shapes for npm
- * consumers (since the source tree is not shipped). Keep both files in sync.
+ * The canonical public types live in the repo-root `index.d.ts` (the only
+ * declaration file shipped to npm). This file simply re-exports the shared
+ * shapes so there is a single source of truth.
  */
 
-export type ColorPickerLocale = 'zh-CN' | 'en-US' | 'ja-JP'
-
-export interface ColorPickerMessages {
-  defaultColor: string
-  themeColors: string
-  standardColors: string
-  moreColors: string
-  pickerLabel: string
-}
-
-export type ColorPickerPlacement =
-  | 'auto'
-  | 'top'
-  | 'bottom'
-  | 'top-start'
-  | 'top-end'
-  | 'bottom-start'
-  | 'bottom-end'
-
-export interface ColorPickerExposed {
-  open: () => void
-  close: () => void
-  focus: () => void
-}
+export type {
+  ColorPickerLocale,
+  ColorPickerMessages,
+  ColorPickerPlacement,
+  ColorPickerExposed
+} from '../../../index'

--- a/packages/color-picker/src/utils.ts
+++ b/packages/color-picker/src/utils.ts
@@ -1,0 +1,160 @@
+/**
+ * 与组件实例无关的纯逻辑：颜色计算、locale 解析、面板方位解析、
+ * 以及跨实例共享的 <html lang> 观察者。抽出以便单元测试。
+ */
+import type { ColorPickerLocale, ColorPickerMessages, ColorPickerPlacement } from './types'
+
+export type ResolvedPlacement = {
+  vertical: 'top' | 'bottom' | 'auto'
+  horizontal: 'left' | 'right' | 'auto'
+}
+
+export const parsePlacement = (p: ColorPickerPlacement): ResolvedPlacement => {
+  if (p === 'auto') return { vertical: 'auto', horizontal: 'auto' }
+  const [v, h] = p.split('-') as ['top' | 'bottom', 'start' | 'end' | undefined]
+  return {
+    vertical: v,
+    horizontal: h ? (h === 'start' ? 'left' : 'right') : 'auto'
+  }
+}
+
+export const localeMessagesMap: Record<ColorPickerLocale, ColorPickerMessages> = {
+  'zh-CN': {
+    defaultColor: '默认颜色',
+    themeColors: '主题颜色',
+    standardColors: '标准颜色',
+    moreColors: '更多颜色...',
+    pickerLabel: '颜色选择器'
+  },
+  'en-US': {
+    defaultColor: 'Default',
+    themeColors: 'Theme Colors',
+    standardColors: 'Standard Colors',
+    moreColors: 'More Colors...',
+    pickerLabel: 'Color picker'
+  },
+  'ja-JP': {
+    defaultColor: 'デフォルトカラー',
+    themeColors: 'テーマカラー',
+    standardColors: '標準カラー',
+    moreColors: 'その他のカラー...',
+    pickerLabel: 'カラーピッカー'
+  }
+}
+
+// 主题颜色
+export const THEME_COLORS = [
+  '#000000', '#ffffff', '#eeece1', '#1e497b', '#4e81bb',
+  '#e2534d', '#9aba60', '#8165a0', '#47acc5', '#f9974c'
+] as const
+
+// 标准颜色
+export const STANDARD_COLORS = [
+  '#c21401', '#ff1e02', '#ffc12a', '#ffff3a', '#90cf5b',
+  '#00af57', '#00afee', '#0071be', '#00215f', '#72349d'
+] as const
+
+// 色板渐变源 [深色, 浅色]
+const COLOR_CONFIG: ReadonlyArray<readonly [string, string]> = [
+  ['#7f7f7f', '#f2f2f2'],
+  ['#0d0d0d', '#808080'],
+  ['#1c1a10', '#ddd8c3'],
+  ['#0e243d', '#c6d9f0'],
+  ['#233f5e', '#dae5f0'],
+  ['#632623', '#f2dbdb'],
+  ['#4d602c', '#eaf1de'],
+  ['#3f3150', '#e6e0ec'],
+  ['#1e5867', '#d9eef3'],
+  ['#99490f', '#fee9da']
+]
+
+export const GRADIENT_STEPS = 5
+
+export const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v))
+
+// 规范化 hex 字符串；非法输入回退到黑色
+export const parseColor = (input: string): string => {
+  if (!input || typeof input !== 'string') return '#000000'
+  let hex = input.trim().toLowerCase()
+  if (!hex.startsWith('#')) hex = '#' + hex
+  if (/^#[0-9a-f]{3}$/.test(hex)) {
+    return '#' + hex[1] + hex[1] + hex[2] + hex[2] + hex[3] + hex[3]
+  }
+  if (/^#[0-9a-f]{6}$/.test(hex)) return hex
+  return '#000000'
+}
+
+export const hexToRgb = (hex: string): [number, number, number] => {
+  const h = parseColor(hex)
+  return [
+    parseInt(h.slice(1, 3), 16),
+    parseInt(h.slice(3, 5), 16),
+    parseInt(h.slice(5, 7), 16)
+  ]
+}
+
+export const rgbToHex = (r: number, g: number, b: number): string => {
+  const toComp = (n: number) => clamp(Math.round(n), 0, 255).toString(16).padStart(2, '0')
+  return '#' + toComp(r) + toComp(g) + toComp(b)
+}
+
+export const gradient = (start: string, end: string, step: number): string[] => {
+  const [sr, sg, sb] = hexToRgb(start)
+  const [er, eg, eb] = hexToRgb(end)
+  const rStep = (er - sr) / step
+  const gStep = (eg - sg) / step
+  const bStep = (eb - sb) / step
+  const out: string[] = []
+  for (let i = 0; i < step; i++) {
+    out.push(rgbToHex(sr + rStep * i, sg + gStep * i, sb + bStep * i))
+  }
+  return out
+}
+
+// 预计算一次的渐变面板：COLOR_PANEL[列][行]，浅 -> 深
+export const COLOR_PANEL: ReadonlyArray<ReadonlyArray<string>> = COLOR_CONFIG.map(
+  ([dark, light]) => gradient(light, dark, GRADIENT_STEPS)
+)
+
+export const normalizeLocale = (locale?: string): ColorPickerLocale => {
+  if (!locale) return 'zh-CN'
+  const l = locale.toLowerCase()
+  if (l.startsWith('zh')) return 'zh-CN'
+  if (l.startsWith('ja')) return 'ja-JP'
+  return 'en-US'
+}
+
+export const detectLocale = (): ColorPickerLocale => {
+  if (typeof document !== 'undefined') {
+    const lang = document.documentElement.lang
+    if (lang) return normalizeLocale(lang)
+  }
+  if (typeof navigator !== 'undefined') return normalizeLocale(navigator.language)
+  return 'zh-CN'
+}
+
+// MutationObserver 单例：所有组件实例共享一个 observer，引用计数为 0 时断开
+type LangListener = (locale: ColorPickerLocale) => void
+const langListeners = new Set<LangListener>()
+let sharedLangObserver: MutationObserver | null = null
+
+export const subscribeLang = (cb: LangListener): (() => void) => {
+  langListeners.add(cb)
+  if (typeof document !== 'undefined' && !sharedLangObserver) {
+    sharedLangObserver = new MutationObserver(() => {
+      const next = detectLocale()
+      langListeners.forEach(fn => fn(next))
+    })
+    sharedLangObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['lang']
+    })
+  }
+  return () => {
+    langListeners.delete(cb)
+    if (langListeners.size === 0 && sharedLangObserver) {
+      sharedLangObserver.disconnect()
+      sharedLangObserver = null
+    }
+  }
+}

--- a/packages/main.ts
+++ b/packages/main.ts
@@ -10,7 +10,7 @@ const components = [
 // 定义 install 方法，接收 Vue 作为参数。如果使用 use 注册插件，则所有的组件都将被注册
 const install: Plugin['install'] = function (app) {
   // 遍历注册全局组件
-  components.map(component => app.component(component.name ?? 'colorPicker', component))
+  components.forEach(component => app.component(component.name ?? 'colorPicker', component))
 }
 
 export default {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,16 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      '@vueuse/core':
-        specifier: ^14.3.0
-        version: 14.3.0(vue@3.5.33(typescript@5.8.3))
-      highlight.js:
-        specifier: ^11.11.1
-        version: 11.11.1
-      vue:
-        specifier: ^3.5.33
-        version: 3.5.33(typescript@5.8.3)
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -27,9 +17,6 @@ importers:
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
-      '@types/web-bluetooth':
-        specifier: ^0.0.21
-        version: 0.0.21
       '@vitejs/plugin-vue':
         specifier: ^6.0.6
         version: 6.0.6(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0))(vue@3.5.33(typescript@5.8.3))
@@ -42,6 +29,9 @@ importers:
       '@vue/server-renderer':
         specifier: ^3.5.34
         version: 3.5.34(vue@3.5.33(typescript@5.8.3))
+      '@vue/test-utils':
+        specifier: ^2.4.11
+        version: 2.4.11(@vue/compiler-dom@3.5.34)(@vue/server-renderer@3.5.34(vue@3.5.33(typescript@5.8.3)))(vue@3.5.33(typescript@5.8.3))
       '@vue/tsconfig':
         specifier: ^0.9.1
         version: 0.9.1(typescript@5.8.3)(vue@3.5.33(typescript@5.8.3))
@@ -54,6 +44,9 @@ importers:
       git-cz:
         specifier: ^4.9.0
         version: 4.9.0
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -75,6 +68,12 @@ importers:
       vitepress:
         specifier: ^1.6.4
         version: 1.6.4(@algolia/client-search@5.52.1)(@types/node@25.6.0)(lightningcss@1.32.0)(postcss@8.5.13)(sass@1.99.0)(search-insights@2.17.3)(typescript@5.8.3)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@25.6.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0))
+      vue:
+        specifier: ^3.5.33
+        version: 3.5.33(typescript@5.8.3)
       vue-tsc:
         specifier: ^3.2.7
         version: 3.2.7(typescript@5.8.3)
@@ -157,6 +156,21 @@ packages:
     resolution: {integrity: sha512-tqZXM+54rWo4mk5jL5Z/flE11nPmNEdXwFBM5py9DkOmbjeCNemfVd45FyM97XdzfZ0dl9uOJC6PYn1FpkeyQg==}
     engines: {node: '>= 14.0.0'}
 
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
@@ -183,6 +197,10 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@conventional-changelog/git-client@2.7.0':
     resolution: {integrity: sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==}
     engines: {node: '>=18'}
@@ -194,6 +212,42 @@ packages:
         optional: true
       conventional-commits-parser:
         optional: true
+
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.10':
+    resolution: {integrity: sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7':
+    resolution: {integrity: sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@docsearch/css@3.8.2':
     resolution: {integrity: sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==}
@@ -404,6 +458,15 @@ packages:
     resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -564,6 +627,10 @@ packages:
       '@types/node':
         optional: true
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
@@ -636,6 +703,9 @@ packages:
 
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
+  '@one-ini/wasm@0.1.1':
+    resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
 
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
@@ -725,6 +795,10 @@ packages:
   '@phun-ky/typeof@2.0.3':
     resolution: {integrity: sha512-oeQJs1aa8Ghke8JIK9yuq/+KjMiaYeDZ38jx7MhkXncXlUKjqQ3wEm2X3qCKyjo+ZZofZj+WsEEiqkTtRuE2xQ==}
     engines: {node: ^20.9.0 || >=22.0.0, npm: '>=10.8.2'}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
@@ -992,8 +1066,17 @@ packages:
     resolution: {integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==}
     engines: {node: '>=18'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -1111,6 +1194,35 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   '@volar/language-core@2.4.28':
     resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
 
@@ -1204,6 +1316,16 @@ packages:
   '@vue/shared@3.5.34':
     resolution: {integrity: sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==}
 
+  '@vue/test-utils@2.4.11':
+    resolution: {integrity: sha512-GDqaqZsA6m2E5vNzej0aYiIb6BX8xV9pNSbbbXKOfEYwg7ZNblVX8suyqmUBThq8VIrgAJNxn+z72hVtUeiWHA==}
+    peerDependencies:
+      '@vue/compiler-dom': 3.x
+      '@vue/server-renderer': 3.x
+      vue: 3.x
+    peerDependenciesMeta:
+      '@vue/server-renderer':
+        optional: true
+
   '@vue/tsconfig@0.9.1':
     resolution: {integrity: sha512-buvjm+9NzLCJL29KY1j1991YYJ5e6275OiK+G4jtmfIb+z4POywbdm0wXusT9adVWqe0xqg70TbI7+mRx4uU9w==}
     peerDependencies:
@@ -1217,11 +1339,6 @@ packages:
 
   '@vueuse/core@12.8.2':
     resolution: {integrity: sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==}
-
-  '@vueuse/core@14.3.0':
-    resolution: {integrity: sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==}
-    peerDependencies:
-      vue: ^3.5.0
 
   '@vueuse/integrations@12.8.2':
     resolution: {integrity: sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==}
@@ -1267,16 +1384,12 @@ packages:
   '@vueuse/metadata@12.8.2':
     resolution: {integrity: sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==}
 
-  '@vueuse/metadata@14.3.0':
-    resolution: {integrity: sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==}
-
   '@vueuse/shared@12.8.2':
     resolution: {integrity: sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==}
 
-  '@vueuse/shared@14.3.0':
-    resolution: {integrity: sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==}
-    peerDependencies:
-      vue: ^3.5.0
+  abbrev@2.0.0:
+    resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1302,6 +1415,10 @@ packages:
   alien-signals@3.1.2:
     resolution: {integrity: sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
@@ -1309,6 +1426,14 @@ packages:
   ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
     engines: {node: '>=4'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
@@ -1320,6 +1445,10 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
@@ -1351,6 +1480,9 @@ packages:
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   birpc@2.9.0:
     resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
 
@@ -1359,6 +1491,9 @@ packages:
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -1397,6 +1532,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -1448,11 +1587,22 @@ packages:
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
 
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
   color-name@1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
 
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
 
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
@@ -1466,6 +1616,9 @@ packages:
 
   confbox@0.2.4:
     resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
+
+  config-chain@1.1.13:
+    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
@@ -1507,6 +1660,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   copy-anything@4.0.5:
     resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
     engines: {node: '>=18'}
@@ -1519,6 +1675,10 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -1530,6 +1690,10 @@ packages:
   data-uri-to-buffer@7.0.0:
     resolution: {integrity: sha512-CuRUx0TXGSbbWdEci3VK/XOZGP3n0P4pIKpsqpVtBqaIIuj3GKK8H45oAqA4Rg8FHipc+CzRdUzmD4YQXxv66Q==}
     engines: {node: '>= 14'}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -1551,6 +1715,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -1615,8 +1782,22 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  editorconfig@1.0.7:
+    resolution: {integrity: sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   emoji-regex-xs@1.0.0:
     resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -1625,6 +1806,10 @@ packages:
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
@@ -1640,6 +1825,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -1751,6 +1939,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1758,6 +1949,10 @@ packages:
   eta@4.5.1:
     resolution: {integrity: sha512-EaNCGm+8XEIU7YNcc+THptWAO5NfKBHHARxt+wxZljj9bTr/+arRoOm9/MpGt4n6xn9fLnPFRSoLD0WFYGFUxQ==}
     engines: {node: '>=20'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -1831,6 +2026,10 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1892,6 +2091,11 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
@@ -1941,10 +2145,6 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
-  highlight.js@11.11.1:
-    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
-    engines: {node: '>=12.0.0'}
-
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
@@ -1954,6 +2154,10 @@ packages:
   hosted-git-info@8.1.0:
     resolution: {integrity: sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -1987,6 +2191,9 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -2044,6 +2251,10 @@ packages:
     resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
     engines: {node: '>= 0.4'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-generator-function@1.1.2:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
     engines: {node: '>= 0.4'}
@@ -2084,6 +2295,9 @@ packages:
   is-obj@2.0.0:
     resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
     engines: {node: '>=8'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -2146,9 +2360,29 @@ packages:
     resolution: {integrity: sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==}
     engines: {node: ^18.17 || >=20.6.1}
 
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  js-beautify@1.15.4:
+    resolution: {integrity: sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  js-cookie@3.0.8:
+    resolution: {integrity: sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==}
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -2275,6 +2509,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
@@ -2295,6 +2533,9 @@ packages:
 
   mdast-util-to-hast@13.2.1:
     resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   memorystream@0.3.1:
     resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
@@ -2346,8 +2587,16 @@ packages:
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   minisearch@7.2.0:
     resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
@@ -2393,6 +2642,11 @@ packages:
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
+  nopt@7.2.1:
+    resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    hasBin: true
+
   normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
 
@@ -2424,6 +2678,10 @@ packages:
   object.assign@4.1.7:
     resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
     engines: {node: '>= 0.4'}
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
 
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
@@ -2473,6 +2731,9 @@ packages:
     peerDependencies:
       quickjs-wasi: ^0.0.1
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parse-json@4.0.0:
     resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==}
     engines: {node: '>=4'}
@@ -2483,6 +2744,9 @@ packages:
   parse-url@9.2.0:
     resolution: {integrity: sha512-bCgsFI+GeGWPAvAiUv63ZorMeif3/U0zaXABGJbOWt5OH2KCaPHF6S+0ok4aqM9RuIPGyZdx9tR9l13PsW4AYQ==}
     engines: {node: '>=14.13.0'}
+
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
@@ -2501,6 +2765,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-type@3.0.0:
     resolution: {integrity: sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==}
@@ -2577,6 +2845,9 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  proto-list@1.2.4:
+    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
   protocols@2.0.2:
     resolution: {integrity: sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==}
 
@@ -2638,6 +2909,10 @@ packages:
     engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
     hasBin: true
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
@@ -2697,6 +2972,10 @@ packages:
     resolution: {integrity: sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   search-insights@2.17.3:
     resolution: {integrity: sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==}
@@ -2761,6 +3040,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -2804,6 +3086,12 @@ packages:
     resolution: {integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
   stdin-discarder@0.3.2:
     resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
     engines: {node: '>=18'}
@@ -2811,6 +3099,14 @@ packages:
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
 
   string-width@8.2.1:
     resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
@@ -2838,6 +3134,10 @@ packages:
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
   strip-ansi@7.1.2:
     resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
@@ -2858,12 +3158,18 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   synckit@0.11.12:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
   tinyexec@1.1.2:
     resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
@@ -2877,9 +3183,28 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.4.9:
+    resolution: {integrity: sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==}
+
+  tldts@7.4.9:
+    resolution: {integrity: sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -2946,6 +3271,10 @@ packages:
 
   undici@7.24.5:
     resolution: {integrity: sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==}
+    engines: {node: '>=20.18.1'}
+
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unist-util-is@6.0.1:
@@ -3071,8 +3400,52 @@ packages:
       postcss:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  vue-component-type-helpers@3.3.8:
+    resolution: {integrity: sha512-troqCMmQodQDqUqn63NQaFi+CDSclSe7sc8VEBFqf5GFLqmGR2Ph3P2WEC7qwpRVyEWsTi/aAr4vyOe/B1hU3g==}
 
   vue-eslint-parser@10.4.0:
     resolution: {integrity: sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==}
@@ -3094,9 +3467,25 @@ packages:
       typescript:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   walk-up-path@4.0.0:
     resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
     engines: {node: 20 || >=22}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -3123,6 +3512,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   wildcard-match@5.1.4:
     resolution: {integrity: sha512-wldeCaczs8XXq7hj+5d/F38JE2r7EXgb6WQDM84RVwxy81T/sxB5e9+uZLK9Q9oNz1mlvjut+QtvgaOQFPVq/g==}
 
@@ -3137,6 +3531,14 @@ packages:
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
@@ -3144,6 +3546,13 @@ packages:
   xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
     engines: {node: '>=12'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yargs-parser@22.0.0:
     resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
@@ -3274,6 +3683,26 @@ snapshots:
     dependencies:
       '@algolia/client-common': 5.52.1
 
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
@@ -3296,6 +3725,10 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@conventional-changelog/git-client@2.7.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)':
     dependencies:
       '@simple-libs/child-process-utils': 1.0.2
@@ -3304,6 +3737,30 @@ snapshots:
     optionalDependencies:
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.4.0
+
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@docsearch/css@3.8.2': {}
 
@@ -3448,6 +3905,8 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
+  '@exodus/bytes@1.15.1': {}
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -3589,6 +4048,15 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.2
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
@@ -3673,6 +4141,8 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
+  '@one-ini/wasm@0.1.1': {}
+
   '@oxc-project/types@0.127.0': {}
 
   '@parcel/watcher-android-arm64@2.5.1':
@@ -3737,6 +4207,9 @@ snapshots:
     optional: true
 
   '@phun-ky/typeof@2.0.3': {}
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@pkgr/core@0.2.9': {}
 
@@ -3930,10 +4403,19 @@ snapshots:
 
   '@simple-libs/stream-utils@1.2.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
 
@@ -4075,6 +4557,47 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.13
       vite: 8.0.10(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)
       vue: 3.5.33(typescript@5.8.3)
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.10(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@volar/language-core@2.4.28':
     dependencies:
@@ -4233,6 +4756,15 @@ snapshots:
 
   '@vue/shared@3.5.34': {}
 
+  '@vue/test-utils@2.4.11(@vue/compiler-dom@3.5.34)(@vue/server-renderer@3.5.34(vue@3.5.33(typescript@5.8.3)))(vue@3.5.33(typescript@5.8.3))':
+    dependencies:
+      '@vue/compiler-dom': 3.5.34
+      js-beautify: 1.15.4
+      vue: 3.5.33(typescript@5.8.3)
+      vue-component-type-helpers: 3.3.8
+    optionalDependencies:
+      '@vue/server-renderer': 3.5.34(vue@3.5.33(typescript@5.8.3))
+
   '@vue/tsconfig@0.9.1(typescript@5.8.3)(vue@3.5.33(typescript@5.8.3))':
     optionalDependencies:
       typescript: 5.8.3
@@ -4247,13 +4779,6 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/core@14.3.0(vue@3.5.33(typescript@5.8.3))':
-    dependencies:
-      '@types/web-bluetooth': 0.0.21
-      '@vueuse/metadata': 14.3.0
-      '@vueuse/shared': 14.3.0(vue@3.5.33(typescript@5.8.3))
-      vue: 3.5.33(typescript@5.8.3)
-
   '@vueuse/integrations@12.8.2(focus-trap@7.8.0)(typescript@5.8.3)':
     dependencies:
       '@vueuse/core': 12.8.2(typescript@5.8.3)
@@ -4266,17 +4791,13 @@ snapshots:
 
   '@vueuse/metadata@12.8.2': {}
 
-  '@vueuse/metadata@14.3.0': {}
-
   '@vueuse/shared@12.8.2(typescript@5.8.3)':
     dependencies:
       vue: 3.5.33(typescript@5.8.3)
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/shared@14.3.0(vue@3.5.33(typescript@5.8.3))':
-    dependencies:
-      vue: 3.5.33(typescript@5.8.3)
+  abbrev@2.0.0: {}
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -4312,11 +4833,19 @@ snapshots:
 
   alien-signals@3.1.2: {}
 
+  ansi-regex@5.0.1: {}
+
   ansi-regex@6.2.2: {}
 
   ansi-styles@3.2.1:
     dependencies:
       color-convert: 1.9.3
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
 
   array-buffer-byte-length@1.0.2:
     dependencies:
@@ -4334,6 +4863,8 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
+
+  assertion-error@2.0.1: {}
 
   ast-types@0.13.4:
     dependencies:
@@ -4357,6 +4888,10 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   birpc@2.9.0: {}
 
   boolbase@1.0.0: {}
@@ -4365,6 +4900,10 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
+
+  brace-expansion@2.1.2:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.5:
     dependencies:
@@ -4414,6 +4953,8 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@6.2.2: {}
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -4456,9 +4997,17 @@ snapshots:
     dependencies:
       color-name: 1.1.3
 
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
   color-name@1.1.3: {}
 
+  color-name@1.1.4: {}
+
   comma-separated-tokens@2.0.3: {}
+
+  commander@10.0.1: {}
 
   compare-func@2.0.0:
     dependencies:
@@ -4475,6 +5024,11 @@ snapshots:
       typedarray: 0.0.6
 
   confbox@0.2.4: {}
+
+  config-chain@1.1.13:
+    dependencies:
+      ini: 1.3.8
+      proto-list: 1.2.4
 
   consola@3.4.2: {}
 
@@ -4525,6 +5079,8 @@ snapshots:
       conventional-commits-parser: 6.4.0
       meow: 13.2.0
 
+  convert-source-map@2.0.0: {}
+
   copy-anything@4.0.5:
     dependencies:
       is-what: 5.5.0
@@ -4543,11 +5099,23 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
 
   data-uri-to-buffer@7.0.0: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -4570,6 +5138,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   deep-is@0.1.4: {}
 
@@ -4628,11 +5198,26 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  eastasianwidth@0.2.0: {}
+
+  editorconfig@1.0.7:
+    dependencies:
+      '@one-ini/wasm': 0.1.1
+      commander: 10.0.1
+      minimatch: 9.0.9
+      semver: 7.7.4
+
   emoji-regex-xs@1.0.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   entities@4.5.0: {}
 
   entities@7.0.1: {}
+
+  entities@8.0.0: {}
 
   error-ex@1.3.4:
     dependencies:
@@ -4698,6 +5283,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -4848,9 +5435,15 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   eta@4.5.1: {}
+
+  expect-type@1.4.0: {}
 
   exsolve@1.0.8: {}
 
@@ -4921,6 +5514,11 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
 
   fsevents@2.3.3:
     optional: true
@@ -5002,6 +5600,15 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   globalthis@1.0.4:
     dependencies:
       define-properties: 1.2.1
@@ -5060,8 +5667,6 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
-  highlight.js@11.11.1: {}
-
   hookable@5.5.3: {}
 
   hosted-git-info@2.8.9: {}
@@ -5069,6 +5674,12 @@ snapshots:
   hosted-git-info@8.1.0:
     dependencies:
       lru-cache: 10.4.3
+
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   html-void-elements@3.0.0: {}
 
@@ -5099,6 +5710,8 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -5158,6 +5771,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-generator-function@1.1.2:
     dependencies:
       call-bound: 1.0.4
@@ -5190,6 +5805,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-obj@2.0.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -5254,7 +5871,49 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.uniqby: 4.7.0
 
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
   jiti@2.6.1: {}
+
+  js-beautify@1.15.4:
+    dependencies:
+      config-chain: 1.1.13
+      editorconfig: 1.0.7
+      glob: 10.5.0
+      js-cookie: 3.0.8
+      nopt: 7.2.1
+
+  js-cookie@3.0.8: {}
+
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.7(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 7.29.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   json-buffer@3.0.1: {}
 
@@ -5354,6 +6013,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.5.2: {}
+
   lru-cache@7.18.3: {}
 
   macos-release@3.4.0: {}
@@ -5377,6 +6038,8 @@ snapshots:
       unist-util-position: 5.0.0
       unist-util-visit: 5.1.0
       vfile: 6.0.3
+
+  mdn-data@2.27.1: {}
 
   memorystream@0.3.1: {}
 
@@ -5422,7 +6085,13 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.2
+
   minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
 
   minisearch@7.2.0: {}
 
@@ -5452,6 +6121,10 @@ snapshots:
     optional: true
 
   node-fetch-native@1.6.7: {}
+
+  nopt@7.2.1:
+    dependencies:
+      abbrev: 2.0.0
 
   normalize-package-data@2.5.0:
     dependencies:
@@ -5500,6 +6173,8 @@ snapshots:
       es-object-atoms: 1.1.1
       has-symbols: 1.1.0
       object-keys: 1.1.1
+
+  obug@2.1.4: {}
 
   ohash@2.0.11: {}
 
@@ -5580,6 +6255,8 @@ snapshots:
       netmask: 2.0.2
       quickjs-wasi: 0.0.1
 
+  package-json-from-dist@1.0.1: {}
+
   parse-json@4.0.0:
     dependencies:
       error-ex: 1.3.4
@@ -5594,6 +6271,10 @@ snapshots:
       '@types/parse-path': 7.1.0
       parse-path: 7.1.0
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
@@ -5603,6 +6284,11 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   path-type@3.0.0:
     dependencies:
@@ -5658,6 +6344,8 @@ snapshots:
   prettier@3.8.3: {}
 
   property-information@7.1.0: {}
+
+  proto-list@1.2.4: {}
 
   protocols@2.0.2: {}
 
@@ -5762,6 +6450,8 @@ snapshots:
       - '@types/node'
       - magicast
       - supports-color
+
+  require-from-string@2.0.2: {}
 
   resolve@1.22.11:
     dependencies:
@@ -5869,6 +6559,10 @@ snapshots:
     optionalDependencies:
       '@parcel/watcher': 2.5.1
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   search-insights@2.17.3: {}
 
   semver@5.7.2: {}
@@ -5950,6 +6644,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   smart-buffer@4.2.0: {}
@@ -5989,12 +6685,28 @@ snapshots:
 
   speakingurl@14.0.1: {}
 
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
+
   stdin-discarder@0.3.2: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.2
 
   string-width@8.2.1:
     dependencies:
@@ -6040,6 +6752,10 @@ snapshots:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
 
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
   strip-ansi@7.1.2:
     dependencies:
       ansi-regex: 6.2.2
@@ -6056,11 +6772,15 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   synckit@0.11.12:
     dependencies:
       '@pkgr/core': 0.2.9
 
   tabbable@6.4.0: {}
+
+  tinybench@2.9.0: {}
 
   tinyexec@1.1.2: {}
 
@@ -6074,9 +6794,25 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyrainbow@3.1.0: {}
+
+  tldts-core@7.4.9: {}
+
+  tldts@7.4.9:
+    dependencies:
+      tldts-core: 7.4.9
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.9
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -6153,6 +6889,8 @@ snapshots:
   undici-types@7.19.2: {}
 
   undici@7.24.5: {}
+
+  undici@7.29.0: {}
 
   unist-util-is@6.0.1:
     dependencies:
@@ -6275,7 +7013,37 @@ snapshots:
       - typescript
       - universal-cookie
 
+  vitest@4.1.10(@types/node@25.6.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.10(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
+
   vscode-uri@3.1.0: {}
+
+  vue-component-type-helpers@3.3.8: {}
 
   vue-eslint-parser@10.4.0(eslint@10.3.0(jiti@2.6.1)):
     dependencies:
@@ -6305,7 +7073,23 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   walk-up-path@4.0.0: {}
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -6356,6 +7140,11 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   wildcard-match@5.1.4: {}
 
   windows-release@7.1.1:
@@ -6366,12 +7155,28 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.1.2
+
   wsl-utils@0.3.1:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
   xml-name-validator@4.0.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yargs-parser@22.0.0: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,7 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./docs/*"]
-    },
-    "types": ["@types/web-bluetooth"]
+    }
   },
   "references": [
     {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  test: {
+    environment: 'jsdom',
+    include: ['packages/**/__tests__/**/*.spec.ts']
+  }
+})


### PR DESCRIPTION
## 改动内容

### 组件功能
- **新增 `teleport` prop**（`true` = body，或传 CSS 选择器）：面板改用 fixed 定位渲染到目标容器，滚动/缩放时自动跟随触发器，解决被 `overflow: hidden` 祖先（表格、弹窗、卡片）裁剪的问题
- **色块网格键盘导航**：roving tabindex，`← → ↑ ↓` 在 7×10 逻辑网格（主题色/渐变面板/标准色）间移动，`Home`/`End` 跳行首行尾，触发器上按 `↓` 打开面板并聚焦第一格；此前需要 Tab 60+ 次才能遍历面板
- **ARIA 结构修正**：单行色块改为 `listbox`/`option`（带 `aria-selected`，大小写不敏感比较），渐变面板补 `role="presentation"` 使 grid 层级合规
- **移除 `@vueuse/core`**：`onClickOutside` 改为面板打开期间的 `pointerdown` 捕获监听，同时检查触发器与面板两个容器（teleport 后面板不在触发器 DOM 内）

### 工程化
- 删除无用运行时依赖 `highlight.js`（源码零引用，每个用户白装 ~1MB）和 `@types/web-bluetooth`
- `vue` 从 `dependencies` 移入 `peerDependencies`（`^3.5.0`）
- `exports` 中 `types` 条件前置，修复 `moduleResolution: bundler/node16` 下类型解析失效
- 补充 `sideEffects`/`unpkg`/`jsdelivr`/`engines`；新增 `prepublishOnly`（发布前强制 type-check + test + lib 构建）；修复指向不存在入口的死脚本
- 纯逻辑抽取到 `utils.ts`；`types.ts` 改为从根 `index.d.ts` re-export，消除双份人工同步
- **新增 Vitest 测试**：36 例覆盖纯函数（hex 解析回退、渐变、locale 归一化、placement 解析）与组件交互（面板开关、选色事件、外部点击、键盘导航、teleport 渲染位置）
- **新增 CI workflow**：push/PR 触发 lint → type-check → test → lib 构建
- 文档（中英 + README）补充 teleport 用法与键盘导航说明；FAQ 语言列表补 ja-JP

## 审查者须知

- **CSS 变量声明方式有变**：组件不再在元素上声明变量默认值，改为所有使用点 `var(--vcp-x, 默认值)` 回退。原因：teleport 后面板脱离 `.m-colorPicker`，若在面板元素上声明默认值，自定义属性「自身声明优先于继承」会导致用户在祖先（如 `.dark .m-colorPicker`）上的覆盖失效。现在 `:root`、`.m-colorPicker`、`.m-colorPicker-box` 任意层级覆盖均生效，向后兼容
- 面板元素保留 `.box` 类名，既有 `.m-colorPicker .box` 用户覆盖样式在非 teleport 模式下依然命中
- lockfile 由 pnpm 10 重新生成，deploy.yml 的 pnpm 版本已同步对齐到 10
- 验证：lint / vue-tsc / 36 测试 / lib 构建 / docs 构建全部通过；产物 ESM 12.3 kB（gzip 4.3 kB）

🤖 Generated with [Claude Code](https://claude.com/claude-code)