### PR TITLE
docs: 新增日语（ja-JP）文档站

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -40,6 +40,34 @@ const CHINESE_FAQ = [
     answer: '支持。点击更多颜色时，会在兼容浏览器中调用 HTML5 原生 color input。'
   }
 ] as const
+const JAPANESE_FAQ = [
+  {
+    question: 'vColorPicker は Vue 3 に対応していますか？',
+    answer: 'はい。vColorPicker は Vue 3 プロジェクト向けに設計されており、標準的な v-model で利用できます。'
+  },
+  {
+    question: 'パネルの文言や言語をカスタマイズできますか？',
+    answer: 'はい。locale プロパティで zh-CN、en-US、ja-JP を指定でき、messages プロパティで組み込みラベルを上書きできます。'
+  },
+  {
+    question: 'TypeScript で使えますか？',
+    answer: 'はい。パッケージにはコンポーネントの props とプラグイン登録の TypeScript 型宣言が含まれています。'
+  },
+  {
+    question: 'ブラウザネイティブのカラーピッカーには対応していますか？',
+    answer: 'はい。「その他のカラー」を選ぶと、対応ブラウザではネイティブの HTML5 color input が開きます。'
+  }
+] as const
+
+type PageLang = 'en' | 'zh-CN' | 'ja-JP'
+
+const HOME_PATHS = ['/', '/zh/', '/ja/']
+
+const getPageLang = (canonicalPath: string): PageLang => {
+  if (canonicalPath.startsWith('/zh/')) return 'zh-CN'
+  if (canonicalPath.startsWith('/ja/')) return 'ja-JP'
+  return 'en'
+}
 
 const getCanonicalPath = (relativePath: string) => {
   const routePath = relativePath
@@ -54,30 +82,33 @@ const getCanonicalPath = (relativePath: string) => {
 }
 
 const getAlternateLinks = (canonicalPath: string): HeadConfig[] => {
-  const isChinesePage = canonicalPath.startsWith('/zh/')
-  const englishUrl = `${SITE_URL}/`
-  const chineseUrl = `${SITE_URL}/zh/`
-
-  if (canonicalPath === '/' || canonicalPath === '/zh/') {
+  if (HOME_PATHS.includes(canonicalPath)) {
     return [
-      ['link', { rel: 'alternate', hreflang: 'en', href: englishUrl }],
-      ['link', { rel: 'alternate', hreflang: 'zh-CN', href: chineseUrl }],
-      ['link', { rel: 'alternate', hreflang: 'x-default', href: englishUrl }]
+      ['link', { rel: 'alternate', hreflang: 'en', href: `${SITE_URL}/` }],
+      ['link', { rel: 'alternate', hreflang: 'zh-CN', href: `${SITE_URL}/zh/` }],
+      ['link', { rel: 'alternate', hreflang: 'ja', href: `${SITE_URL}/ja/` }],
+      ['link', { rel: 'alternate', hreflang: 'x-default', href: `${SITE_URL}/` }]
     ]
   }
 
+  const hreflang = getPageLang(canonicalPath) === 'ja-JP' ? 'ja' : getPageLang(canonicalPath)
   return [
-    ['link', { rel: 'alternate', hreflang: isChinesePage ? 'zh-CN' : 'en', href: `${SITE_URL}${canonicalPath}` }]
+    ['link', { rel: 'alternate', hreflang, href: `${SITE_URL}${canonicalPath}` }]
   ]
 }
 
 const getStructuredData = (canonicalPath: string, title: string, description: string): HeadConfig[] => {
-  if (canonicalPath !== '/' && canonicalPath !== '/zh/') {
+  if (!HOME_PATHS.includes(canonicalPath)) {
     return []
   }
 
-  const isChinesePage = canonicalPath === '/zh/'
-  const faqEntries = isChinesePage ? CHINESE_FAQ : ENGLISH_FAQ
+  const pageLang = getPageLang(canonicalPath)
+  const faqMap: Record<PageLang, typeof ENGLISH_FAQ | typeof CHINESE_FAQ | typeof JAPANESE_FAQ> = {
+    'en': ENGLISH_FAQ,
+    'zh-CN': CHINESE_FAQ,
+    'ja-JP': JAPANESE_FAQ
+  }
+  const faqEntries = faqMap[pageLang]
   const pageUrl = `${SITE_URL}${canonicalPath}`
   const structuredData = [
     {
@@ -85,7 +116,7 @@ const getStructuredData = (canonicalPath: string, title: string, description: st
       '@type': 'WebSite',
       name: title,
       url: SITE_URL,
-      inLanguage: isChinesePage ? 'zh-CN' : 'en'
+      inLanguage: pageLang === 'en' ? 'en' : pageLang
     },
     {
       '@context': 'https://schema.org',
@@ -180,6 +211,25 @@ export default defineConfig({
           label: '页面导航'
         }
       }
+    },
+    ja: {
+      label: '日本語',
+      lang: 'ja-JP',
+      title: 'vColorPicker',
+      description: 'Vue 3 向けカラーピッカーコンポーネント',
+      link: '/ja/',
+      themeConfig: {
+        nav: [
+          { text: 'ホーム', link: '/ja/' },
+          { text: 'GitHub', link: 'https://github.com/zuley/vue-color-picker' }
+        ],
+        footer: {
+          message: '作者：<a href="https://rxshc.com/" target="_blank" rel="noreferrer">rxshc.com</a>'
+        },
+        outline: {
+          label: 'このページ'
+        }
+      }
     }
   },
 
@@ -189,12 +239,13 @@ export default defineConfig({
       return items
         .filter(item => !item.url.endsWith('/404.html'))
         .map(item => {
-          if (item.url === `${SITE_URL}/` || item.url === `${SITE_URL}/zh/`) {
+          if (HOME_PATHS.some(path => item.url === `${SITE_URL}${path}`)) {
             return {
               ...item,
               links: [
                 { lang: 'en', hreflang: 'en', url: `${SITE_URL}/` },
-                { lang: 'zh-CN', hreflang: 'zh-CN', url: `${SITE_URL}/zh/` }
+                { lang: 'zh-CN', hreflang: 'zh-CN', url: `${SITE_URL}/zh/` },
+                { lang: 'ja-JP', hreflang: 'ja', url: `${SITE_URL}/ja/` }
               ]
             }
           }
@@ -207,10 +258,18 @@ export default defineConfig({
   transformHead({ pageData, title, description }): HeadConfig[] {
     const canonicalPath = getCanonicalPath(pageData.relativePath)
     const canonicalUrl = `${SITE_URL}${canonicalPath}`
-    const isChinesePage = canonicalPath.startsWith('/zh/')
-    const keywords = isChinesePage
-      ? 'Vue3 颜色选择器, Vue color picker, vColorPicker, 前端组件'
-      : 'Vue 3 color picker, Vue color picker component, vColorPicker, frontend UI component'
+    const pageLang = getPageLang(canonicalPath)
+    const keywordsMap: Record<PageLang, string> = {
+      'zh-CN': 'Vue3 颜色选择器, Vue color picker, vColorPicker, 前端组件',
+      'ja-JP': 'Vue 3 カラーピッカー, Vue color picker, vColorPicker, フロントエンドコンポーネント',
+      'en': 'Vue 3 color picker, Vue color picker component, vColorPicker, frontend UI component'
+    }
+    const keywords = keywordsMap[pageLang]
+    const ogLocaleMap: Record<PageLang, string> = {
+      'zh-CN': 'zh_CN',
+      'ja-JP': 'ja_JP',
+      'en': 'en_US'
+    }
 
     return [
       ['link', { rel: 'canonical', href: canonicalUrl }],
@@ -220,7 +279,7 @@ export default defineConfig({
       ['meta', { property: 'og:url', content: canonicalUrl }],
       ['meta', { property: 'og:image', content: DEFAULT_OG_IMAGE }],
       ['meta', { property: 'og:image:alt', content: 'vColorPicker preview image' }],
-      ['meta', { property: 'og:locale', content: isChinesePage ? 'zh_CN' : 'en_US' }],
+      ['meta', { property: 'og:locale', content: ogLocaleMap[pageLang] }],
       ['meta', { name: 'twitter:title', content: title }],
       ['meta', { name: 'twitter:description', content: description }],
       ['meta', { name: 'twitter:image', content: DEFAULT_OG_IMAGE }],

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -1,0 +1,261 @@
+---
+layout: home
+hero:
+  name: vColorPicker
+  text: Vue 3 カラーピッカー
+  tagline: 軽量でアクセシブルな Vue 3 カラーピッカーコンポーネント
+  actions:
+    - theme: brand
+      text: はじめる
+      link: /ja/#installation
+    - theme: alt
+      text: GitHub
+      link: https://github.com/zuley/vue-color-picker
+
+features:
+  - title: 使いやすい
+    details: シンプルな v-model API。角丸とトランジションを備えた洗練された UI
+  - title: アクセシブル
+    details: キーボードナビゲーション、ARIA ロール、フォーカス管理を完備。スクリーンリーダーにそのまま対応
+  - title: SSR フレンドリー
+    details: 決定的なファーストペイント、hydration 安全なロケール検出、共有 MutationObserver
+  - title: テーマカスタマイズ
+    details: CSS Variables を上書きするだけで配色やサイズを変更可能。セレクタの深掘りは不要
+---
+
+<script setup>
+import { ref } from 'vue'
+const color = ref('#ff0000')
+const englishColor = ref('#3b82f6')
+const japaneseColor = ref('#10b981')
+const topColor = ref('#f59e0b')
+</script>
+
+## デモ
+
+<div class="demo-container">
+  <colorPicker v-model="color" />
+  <p>選択中の色: <code>{{ color }}</code></p>
+</div>
+
+## 多言語対応
+
+<div class="demo-container">
+  <colorPicker v-model="englishColor" locale="en-US" />
+  <p>英語表示: <code>{{ englishColor }}</code></p>
+  <colorPicker v-model="japaneseColor" locale="ja-JP" />
+  <p>日本語表示: <code>{{ japaneseColor }}</code></p>
+</div>
+
+```vue
+<template>
+  <colorPicker
+    v-model="color"
+    locale="ja-JP"
+    :messages="{ moreColors: 'カスタムラベル...' }"
+  />
+</template>
+```
+
+## パネルの表示位置
+
+デフォルトではビューポートの空きスペースに応じて自動配置されます。`placement` プロパティで任意の方向に固定することもできます。
+
+<div class="demo-container">
+  <colorPicker v-model="topColor" placement="top-end" />
+  <p><code>top-end</code> に固定: <code>{{ topColor }}</code></p>
+</div>
+
+```vue
+<colorPicker v-model="color" placement="top-end" />
+<colorPicker v-model="color" placement="bottom" /> <!-- 縦方向のみ固定、横方向は自動 -->
+```
+
+## Teleport
+
+ピッカーが `overflow: hidden` を持つコンテナ（テーブル、ダイアログ、カードなど）の中にあると、パネルが切り取られることがあります。`teleport` を設定すると、パネルを `document.body`（または任意の CSS セレクタ）に描画し、スクロールやリサイズに追従する fixed 配置になります。
+
+```vue
+<colorPicker v-model="color" teleport />
+<colorPicker v-model="color" teleport="#popup-root" />
+```
+
+<div id="installation"></div>
+
+## インストール
+
+```bash
+npm install vcolorpicker -S
+```
+
+## 使い方
+
+`main.js` でプラグインを登録します：
+
+```js
+import { createApp } from 'vue'
+import vcolorpicker from 'vcolorpicker'
+import App from './App.vue'
+
+const app = createApp(App)
+app.use(vcolorpicker)
+app.mount('#app')
+```
+
+コンポーネント内で使用します：
+
+```vue
+<template>
+  <colorPicker v-model="color" />
+</template>
+
+<script setup>
+import { ref } from 'vue'
+const color = ref('#ff0000')
+</script>
+```
+
+## プロパティ Props
+
+| プロパティ | 型 | デフォルト | 説明 |
+| --- | --- | --- | --- |
+| `v-model` / `modelValue` | `string` | — | 現在の色の値 |
+| `defaultColor` | `string` | `#000000` | 「デフォルトカラー」ボタンでリセットされる色 |
+| `disabled` | `boolean` | `false` | 無効状態 |
+| `locale` | `'zh-CN' \| 'en-US' \| 'ja-JP'` | 自動検出 | パネルの組み込み文言の言語。省略時は `<html lang>` / `navigator.language` に追従 |
+| `messages` | `Partial<ColorPickerMessages>` | — | 組み込みラベルをカスタム文言で上書き |
+| `placement` | `ColorPickerPlacement` | `'auto'` | パネル位置：`'auto'` / `'top'` / `'bottom'` / `'top-start'` / `'top-end'` / `'bottom-start'` / `'bottom-end'`。`'auto'` はビューポートの空きスペースで自動決定、方向指定時はその軸を固定 |
+| `teleport` | `boolean \| string` | `false` | パネルを `body`（`true`）または CSS セレクタで指定したコンテナに描画し、祖先の `overflow: hidden` による切り取りを回避 |
+
+## イベント
+
+| イベント名 | 引数 | 説明 |
+| --- | --- | --- |
+| `change` | `(color: string)` | 色の値が変更されたとき |
+| `update:modelValue` | `(color: string)` | `v-model` 同期イベント |
+| `open` | — | パネルが開いたとき |
+| `close` | — | パネルが閉じたとき（外側クリック / Esc / 色選択後の自動クローズ）|
+| `hover` | `(color: string)` | スウォッチにホバーしたとき。離れると空文字列を送出 |
+
+```vue
+<colorPicker v-model="color" @change="onColorChange" />
+```
+
+## 命令的 API
+
+テンプレート ref 経由で公開されるメソッド：
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { ColorPickerInstance } from 'vcolorpicker'
+
+const pickerRef = ref<ColorPickerInstance>()
+const color = ref('#ff0000')
+
+const openProgrammatically = () => pickerRef.value?.open()
+</script>
+
+<template>
+  <colorPicker ref="pickerRef" v-model="color" />
+  <button @click="openProgrammatically">パネルを開く</button>
+</template>
+```
+
+| メソッド | 説明 |
+| --- | --- |
+| `open()` | パネルを開く（`disabled` 時は無効）|
+| `close()` | パネルを閉じる |
+| `focus()` | フォーカスをトリガーボタンに戻す |
+
+## アクセシビリティ (a11y)
+
+- トリガーボタンは `Tab` でフォーカス可能。`Enter` / `Space` で開閉、フォーカス中に `↑` / `↓` を押すとパネルを開いて最初のスウォッチにフォーカス
+- スウォッチグリッドはローミングフォーカス（roving tabindex）方式：`Tab` 一回でグリッドに入り、`←` `→` `↑` `↓` でスウォッチ間を移動、`Home` / `End` で行頭 / 行末へジャンプ、`Enter` / `Space` で選択
+- パネルを開いた状態で `Esc` を押すと閉じてフォーカスをトリガーに戻す
+- トリガーは `role="button"` + `aria-haspopup="dialog"` + `aria-expanded`、パネルは `role="dialog"`、各スウォッチは `aria-label="#RRGGBB"` を持つ
+- フォーカスリングは `:focus-visible` を使用し、マウス操作時には表示されない
+
+## SSR / Nuxt
+
+- Node 環境で `document` / `navigator` が存在しない場合、初期ロケールは `zh-CN`（または明示的な `locale` プロパティ）に固定され、サーバーとクライアントのファーストペイントが一致するため hydration mismatch は発生しません
+- 実際の言語検出は `onMounted` 後に実行されます。マウント後に中国語から別の言語へ切り替わるちらつきを避けたい場合は、**SSR プロジェクトでは明示的に `locale` プロパティを渡すことを推奨します**
+- `<html lang>` を監視する `MutationObserver` はモジュールレベルのシングルトンで、複数インスタンスでも 1 つの observer を共有します
+
+## CSS Variables によるテーマ
+
+セレクタの深掘りなしで、以下のカスタムプロパティを上書きするだけでテーマを変更できます：
+
+```css
+.m-colorPicker {
+  --vcp-swatch-size: 15px;
+  --vcp-panel-width: 190px;
+  --vcp-panel-bg: #fff;
+  --vcp-panel-border: 1px solid #ddd;
+  --vcp-panel-radius: 2px;
+  --vcp-panel-shadow: 0 8px 24px rgba(0, 0, 0, .18);
+  --vcp-panel-padding: 10px;
+  --vcp-text-color: #333;
+  --vcp-focus-color: #4e81bb;
+  --vcp-transition: .3s ease;
+  --vcp-z-index: 10000;
+}
+```
+
+例：ダークテーマ
+
+```css
+.dark .m-colorPicker {
+  --vcp-panel-bg: #1f1f1f;
+  --vcp-panel-border: 1px solid #333;
+  --vcp-text-color: #eee;
+}
+```
+
+> `teleport` を有効にするとパネルは `.m-colorPicker` の子孫ではなくなるため、テーマ変数は `.m-colorPicker-box`（パネルのルート）にも上書きするか、`:root` に定義して両方をカバーしてください。
+
+## TypeScript
+
+パッケージからエクスポートされる型：
+
+```ts
+import type {
+  ColorPickerProps,
+  ColorPickerEmits,
+  ColorPickerExposed,
+  ColorPickerInstance,
+  ColorPickerLocale,
+  ColorPickerMessages,
+  ColorPickerPlacement
+} from 'vcolorpicker'
+```
+
+## よくある質問
+
+### vColorPicker は Vue 3 に対応していますか？
+
+はい。vColorPicker は Vue 3 向けに設計されており、標準的な `v-model` API で利用できます。
+
+### パネルの言語を切り替えられますか？
+
+はい。`locale="zh-CN"`、`locale="en-US"`、`locale="ja-JP"` で組み込みの翻訳を利用でき、`messages` で任意のラベルを上書きすることもできます。
+
+### TypeScript で使えますか？
+
+はい。パッケージには props、emits、インスタンスメソッド、ヘルパー型を含む完全な型宣言が同梱されています。
+
+### ブラウザネイティブのカラーピッカーには対応していますか？
+
+はい。`その他のカラー...` をクリックすると、対応ブラウザでは HTML5 ネイティブの color input が開きます。
+
+### キーボードやスクリーンリーダーで操作できますか？
+
+はい。`Tab` でフォーカス、`Enter` / `Space` で操作、`Esc` で閉じることができ、ARIA ロールとラベルもすべて設定済みです。
+
+## スポンサー
+
+- [AI Prompt Card](https://aipromptcard.app)：シェアできる AI プロンプトカードを生成
+- [Convert Image to WebP](https://convertimagetowebp.app)：オフラインで画像を WebP に変換
+- [Open Agent Skills](https://openagentskills.dev)
+- [Tools Online](https://toolsonline.run)
+- [UI UX Pro Max Skill](https://ui-ux-pro-max-skill.com)


### PR DESCRIPTION
## 改动内容

- 新增 `docs/ja/index.md` 完整日语文档页，结构与中英文版一致（含 teleport 用法、键盘导航、SSR 注意事项、FAQ）
- `config.ts` 新增 `ja` locale（导航/大纲界面文案为日语），语言切换器现为 English / 中文 / 日本語
- 新增日语 FAQPage JSON-LD 结构化数据
- hreflang / sitemap / og:locale / keywords 从两语言硬编码重构为 `getPageLang()` 统一分派；三语首页互相声明 `en` / `zh-CN` / `ja` 交替链接 + `x-default`

## 验证

- `docs:build` 成功生成 `/ja/index.html`
- 英文首页输出 `hreflang="ja"` 指向 `/ja/`；日语页 FAQPage JSON-LD 已确认
- lint 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)